### PR TITLE
Allow shard name to be an empty string.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -66,10 +66,10 @@ object Validate {
       for {
         _ <- Log[F].warn(ignore(b, s"block signature algorithm is empty."))
       } yield false
-    } else if (b.shardId.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block shard identifier is empty."))
-      } yield false
+//    } else if (b.shardId.isEmpty) {
+//      for {
+//        _ <- Log[F].warn(ignore(b, s"block shard identifier is empty."))
+//      } yield false
     } else if (b.postStateHash.isEmpty) {
       for {
         _ <- Log[F].warn(ignore(b, s"block post state hash is empty."))

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -492,7 +492,7 @@ class ValidateTest
         _ <- Validate.formatOfFields[IO](genesis.copy(blockHash = ByteString.EMPTY)) shouldBeF false
         _ <- Validate.formatOfFields[IO](genesis.copy(sig = ByteString.EMPTY)) shouldBeF false
         _ <- Validate.formatOfFields[IO](genesis.copy(sigAlgorithm = "")) shouldBeF false
-        _ <- Validate.formatOfFields[IO](genesis.copy(shardId = "")) shouldBeF false
+//        _ <- Validate.formatOfFields[IO](genesis.copy(shardId = "")) shouldBeF false
         _ <- Validate.formatOfFields[IO](
               genesis.copy(postStateHash = ByteString.EMPTY)
             ) shouldBeF false

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeMain.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeMain.scala
@@ -364,7 +364,7 @@ object NodeMain {
   private def checkShardNameOnlyAscii[F[_]: Sync: Log](shardName: String): F[Unit] =
     (Log[F].error("Shard name should contain only ASCII characters") >>
       Sync[F].raiseError(new RuntimeException("Invalid shard name")))
-      .whenA(!shardName.onlyAscii)
+      .unlessA(shardName.isEmpty || shardName.onlyAscii)
 
   private def logConfiguration[F[_]: Sync: Log](
       conf: NodeConf,


### PR DESCRIPTION
## Overview
Allow shard name to be an empty string.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
