### PR TITLE
Put constrain on in memory representation of a message.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -316,22 +316,15 @@ object Validate {
   ): F[Option[Boolean]] =
     for {
       msgMap <- BlockDagStorage[F].getRepresentation.map(_.dagMessageState.msgMap)
-//      justifications = b.justifications.map(msgMap)
     } yield for {
-      // TODO: temporary don't expect that all justifications are available in msgMap to satisfy the failing tests
-      //  - with multi-parent finalizer all messages should be available
-      justifications <- b.justifications.map(msgMap.get).sequence
-      prevMsg        <- justifications.find(_.sender == b.sender)
-      res = justifications.forall { just =>
-        val justPrevMsgOpt = prevMsg.parents.map(msgMap).find(_.sender == just.sender)
-        justPrevMsgOpt.forall { justPrevMsg =>
-          // Check that previous sender's message did not seen nothing more then supplied message
-          val seenByJust     = just.seen
-          val seenByJustPrev = justPrevMsg.seen
-          (seenByJustPrev -- seenByJust).isEmpty
-        }
-      }
-    } yield res
+      currJs  <- b.justifications.map(msgMap.get).sequence
+      prevMsg <- currJs.find(_.sender == b.sender)
+      prevJs  <- prevMsg.parents.toList.map(msgMap.get).sequence
+    } yield {
+      val parentsHeights     = currJs.map { case m => m.sender -> m.height }.toMap
+      val prevParentsHeights = prevJs.map { case m => m.sender -> m.height }.toMap
+      !parentsHeights.exists { case (v, h) => prevParentsHeights.get(v).exists(_ > h) }
+    }
 
   /**
     * If block contains an invalid justification block B and the creator of B is still bonded,


### PR DESCRIPTION
## Overview
Due to lack of garbage collection and how in memory views are created, with grows of blockchain in memory state grows (8 GB for 25k blocks), also replay time grows.

This PR puts a dirty fix to constrain in memory view by only 100 latest dag rows in the view of message.
It is enough for round robin propose, also it is expected to be enough for many cases with merging under synchrony.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
