### PR TITLE
Enable LFS. Exposes necessity for more than just LFS state.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
@@ -20,6 +20,7 @@ import coop.rchain.models.{BlockHash => _, _}
 import coop.rchain.sdk.error.FatalError
 import coop.rchain.shared._
 import cats.effect.Temporal
+import coop.rchain.shared.syntax.sharedSyntaxKeyValueTypedStore
 
 final case class ParsingError(details: String)
 
@@ -91,29 +92,44 @@ object MultiParentCasper {
 
       // If new fringe is finalized, merge it
       newFringeResult <- newFringeHashes.traverse { fringe =>
-                          val (mScope, baseOpt) =
-                            MergeScope.fromDag(fringe, prevFringeHashes, dag.childMap, msgMap)
-                          for {
-                            baseStateOpt <- baseOpt.traverse { h =>
-                                             BlockStore[F]
-                                               .getUnsafe(h)
-                                               .map(_.postStateHash.toBlake2b256Hash)
-                                           }
-                            result <- MergeScope.merge(
-                                       mScope,
-                                       baseStateOpt.getOrElse(prevFringeState),
-                                       dag.fringeStates,
-                                       RuntimeManager[F].getHistoryRepo,
-                                       BlockIndex.getBlockIndex[F](_)
-                                     )
-                            (finalizedState, rejected) = result
-                            finalizedStateStr = PrettyPrinter.buildString(
-                              finalizedState.toByteString
-                            )
-                            rejectedDeploysStr = PrettyPrinter.buildString(rejected)
-                            msgFinalized       = s"Finalized fringe state: $finalizedStateStr, rejectedDeploys: $rejectedDeploysStr"
-                            _                  <- Log[F].info(msgFinalized)
-                          } yield result
+                          val mergeFringe = {
+                            val (mScope, baseOpt) =
+                              MergeScope.fromDag(fringe, prevFringeHashes, dag.childMap, msgMap)
+                            for {
+                              baseStateOpt <- baseOpt.traverse { h =>
+                                               BlockStore[F]
+                                                 .getUnsafe(h)
+                                                 .map(_.postStateHash.toBlake2b256Hash)
+                                             }
+                              result <- MergeScope.merge(
+                                         mScope,
+                                         baseStateOpt.getOrElse(prevFringeState),
+                                         dag.fringeStates,
+                                         RuntimeManager[F].getHistoryRepo,
+                                         BlockIndex.getBlockIndex[F](_)
+                                       )
+                            } yield result
+                          }
+                          (MergeScope.findSingleTip(fringe, dag) match {
+                            case Some(tip) =>
+                              for {
+                                state <- BlockStore[F]
+                                          .get1(tip)
+                                          .map(_.get.postStateHash.toBlake2b256Hash)
+                                rjFin <- fringe.toList
+                                          .traverse(BlockStore[F].get1)
+                                          .map(_.flatMap(_.get.rejectedDeploys))
+                              } yield state -> rjFin.toSet
+                            case _ => mergeFringe
+                          }).flatTap { result =>
+                            val (finalizedState, rejected) = result
+                            val finalizedStateStr =
+                              PrettyPrinter.buildString(finalizedState.toByteString)
+                            val rejectedDeploysStr = PrettyPrinter.buildString(rejected)
+                            val msgFinalized =
+                              s"New finalized fringe state: $finalizedStateStr, rejectedDeploys: $rejectedDeploysStr"
+                            Log[F].info(msgFinalized)
+                          }
                         }
       (fringeState, rejectedDeploys) = newFringeResult getOrElse (prevFringeState, prevFringeRejectedDeploys)
 
@@ -122,7 +138,8 @@ object MultiParentCasper {
       newFringe  = newFringeHashes.getOrElse(prevFringeHashes)
 
       // Merge conflict scope (non-finalized blocks above fringe)
-      conflictScopeMergeResult <- parentHashes.toSeq match {
+      minGenJs = MergeScope.minGenJs(parentHashes, dag)
+      conflictScopeMergeResult <- minGenJs.toSeq match {
                                    case Seq(parent) =>
                                      BlockStore[F]
                                        .getUnsafe(parent)

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
@@ -90,7 +90,7 @@ final case class BlockReceiverState[MId: Show] private (
           // Update blocks state, keep unseen parents only
           val parentsNotStored = parents.filter(_._2).map(_._1).toSet
           val unseenParents    = parentsNotStored -- blocksSt.keySet -- receiveSt.keySet - id
-          val newBlocksSt      = blocksSt + ((id, unseenParents))
+          val newBlocksSt      = blocksSt + ((id, parents.map(_._1).toSet))
 
           // Update block status to received and set unseen parents to Pending receive state
           val newReceiveStored  = receiveSt + ((id, EndStoreBlock))
@@ -219,7 +219,7 @@ object BlockReceiver {
     // Check if block should be stored
     def checkIfKnown(b: BlockMessage): F[Boolean] =
       BlockDagStorage[F].getRepresentation.map { dag =>
-        dag.heightMap.headOption.map(_._1).getOrElse(-1L) > b.blockNumber
+        dag.contains(b.blockHash) //dag.heightMap.headOption.map(_._1).getOrElse(-1L) > b.blockNumber
       }
 
     def requestMissingDependencies(deps: Set[BlockHash]): F[Unit] =
@@ -252,7 +252,13 @@ object BlockReceiver {
                           .traverse { hash =>
                             BlockStore[F].contains(hash).not.map((hash, _))
                           }
-              pendingRequests <- state.modify(_.endStored(block.blockHash, parents))
+              dag <- BlockDagStorage[F].getRepresentation
+              pendingRequests <- state.modify(
+                                  _.endStored(
+                                    block.blockHash,
+                                    parents.filterNot(x => dag.contains(x._1))
+                                  )
+                                )
 
               // Notify BlockRetriever of finished validation of block
               _ <- BlockRetriever[F].ackReceived(block.blockHash)
@@ -273,7 +279,7 @@ object BlockReceiver {
                   }
             } yield ()
           for {
-            isOfInterest <- shouldCheck &&^ checkIfKnown(block).not
+            isOfInterest <- checkIfKnown(block).not &&^ shouldCheck
             // Log if block is ignored
             _ <- logNotOfInterest(block).unlessA(isOfInterest)
             // Save to store if block is of interest and send request for missing dependencies

--- a/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
@@ -228,23 +228,34 @@ object LfsTupleSpaceRequester {
         .terminateAfter(_.isFinished) concurrently responseStream
     }
 
-    val stateHash                   = fringe.stateHash.toBlake2b256Hash
-    val startRequest: StatePartPath = Seq((stateHash, None))
-    for {
-      // Write last finalized state root
-      _ <- stateImporter.setRoot(stateHash)
+    def loadState(stateHash: Blake2b256Hash): F[Stream[F, ST[StatePartPath]]] = {
+      val startRequest: StatePartPath = Seq((stateHash, None))
+      for {
+        // Write last finalized state root
+        _ <- stateImporter.setRoot(stateHash)
 
-      // Requester state
-      st <- Ref.of[F, ST[StatePartPath]](ST(Seq(startRequest)))
+        // Requester state
+        st <- Ref.of[F, ST[StatePartPath]](ST(Seq(startRequest)))
 
-      // Queue to trigger processing of requests. `True` to resend requests.
-      requestQueue <- Channel.bounded[F, Boolean](capacity = 2)
+        // Queue to trigger processing of requests. `True` to resend requests.
+        requestQueue <- Channel.bounded[F, Boolean](capacity = 2)
 
-      // Light the fire! / Starts the first request for chunk of state
-      // - `true` if requested chunks should be re-requested
-      _ <- requestQueue.trySend(false)
+        // Light the fire! / Starts the first request for chunk of state
+        // - `true` if requested chunks should be re-requested
+        _ <- requestQueue.trySend(false)
 
-      // Create tuple space state receiver stream
-    } yield createStream(st, requestQueue)
+        // Create tuple space state receiver stream
+      } yield createStream(st, requestQueue)
+    }
+
+    // load final state hash + auxiliary hashes (TODO remove these)
+    val toLoad = (fringe.stateHashes + fringe.stateHash)
+      .map(Blake2b256Hash.fromByteString)
+      .toList
+
+    Log[F].info(s"Loading tuple space state for ${toLoad.mkString("; ")}") *>
+      toLoad
+        .traverse(loadState)
+        .map(Stream.emits(_).flatten)
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeLaunch.scala
@@ -75,7 +75,7 @@ object NodeLaunch {
 
         // Store genesis block
         _             <- BlockStore[F].put(genesisBlock)
-        genesisFringe = FinalizedFringe(hashes = Seq(), genesisBlock.preStateHash)
+        genesisFringe = FinalizedFringe(hashes = Seq(), genesisBlock.preStateHash, Set())
         _             <- ApprovedStore[F].putApprovedBlock(genesisFringe)
 
         // Add genesis block to DAG

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
@@ -293,9 +293,29 @@ class NodeRunning[F[_]
         latestFringeHashes    = dag.dagMessageState.latestFringe.map(_.id)
         fringeData            = dag.fringeStates(latestFringeHashes)
         latestFringeStateHash = fringeData.stateHash
+
+        // states of fringes referenced by last 100 blocks
+        // TODO this is a hack to make merging work
+        //  since final fringes are merged. It should not be done this way
+        blocksRange = dag.heightMap
+          .takeRight(100)
+          .values
+          .flatten
+          .toList
+        miscFinalStateHashes = blocksRange
+          .map(x => dag.dagMessageState.msgMap(x).fringe)
+          .map(dag.fringeStates)
+          .map(_.stateHash.toByteString)
+          .toSet
+        mistPrePostStateHashes <- blocksRange
+                                   .traverse(BlockStore[F].getUnsafe)
+                                   .map(_.flatMap(b => List(b.preStateHash, b.postStateHash)))
+        miscStateHashes = miscFinalStateHashes ++ mistPrePostStateHashes
+
         fringeResponse = FinalizedFringe(
           latestFringeHashes.toList,
-          latestFringeStateHash.toByteString
+          latestFringeStateHash.toByteString,
+          miscStateHashes
         )
 
         _ <- handleFinalizedFringeRequest(peer, fringeResponse)

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
@@ -208,7 +208,7 @@ class NodeSyncing[F[_]
       // TODO: height map cannot be used here because invalid blocks can have
       //  invalid block number which will break sequence in height map
       // Add sorted DAG in order from approved block to oldest
-      _ <- heightMap.flatMap(_._2).toList.reverse.traverse_ { hash =>
+      _ <- heightMap.flatMap(_._2).toList.traverse_ { hash =>
             for {
               block <- BlockStore[F].getUnsafe(hash)
               // TODO: blocks added to DAG without validation will have flag `processed=false` so invalid flag is not applicable

--- a/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
@@ -29,6 +29,17 @@ final case class MergeScope(finalScope: Set[BlockHash], conflictScope: Set[Block
 
 object MergeScope {
 
+  def minGenJs(jss: Set[BlockHash], dag: DagRepresentation): Set[BlockHash] =
+    jss.filterNot(
+      j => jss.exists(j2 => (dag.dagMessageState.msgMap(j2).seen - j2).contains(j))
+    )
+
+  def findSingleTip(fringe: Set[BlockHash], dag: DagRepresentation): Option[BlockHash] =
+    minGenJs(fringe, dag).toList match {
+      case List(singleTip) => Some(singleTip)
+      case _               => None
+    }
+
   /**
     * Create Merge scope from DAG
     * @param mergeFringe tip messages of the DAG

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
@@ -32,7 +32,7 @@ class LfsBlockRequesterEffectsSpec extends AnyFlatSpec with Matchers with Fs2Str
   }
 
   def createFinalizedFringe(block: BlockMessage): FinalizedFringe =
-    FinalizedFringe(block.justifications, block.postStateHash)
+    FinalizedFringe(block.justifications, block.postStateHash, Set())
 
   val hash9 = mkHash("9")
   val hash8 = mkHash("8")

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterEffectsSpec.scala
@@ -23,7 +23,7 @@ import cats.effect.unsafe.implicits.global
 class LfsStateRequesterEffectsSpec extends AnyFlatSpec with Matchers with Fs2StreamMatchers {
 
   def createFinalizedFringe(block: BlockMessage): FinalizedFringe =
-    FinalizedFringe(block.justifications, block.postStateHash)
+    FinalizedFringe(block.justifications, block.postStateHash, Set())
 
   // Create hash from hex string (padding to 32 bytes)
   def createHash(s: String) = Blake2b256Hash.fromHex(s.padTo(64, '0'))

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -92,7 +92,7 @@ case class TestNode[F[_]: Async](
   implicit val connectionsCell: Ref[F, Connections]          = connectionsCellEffect
   implicit val rp: RPConfAsk[F]                              = rpConfAskEffect
 
-  val finalizedFringe = FinalizedFringe(Seq(genesis.blockHash), genesis.postStateHash)
+  val finalizedFringe = FinalizedFringe(Seq(genesis.blockHash), genesis.postStateHash, Set())
 
   val postGenesisStateHash = genesis.postStateHash
 

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -27,6 +27,7 @@ message FinalizedFringeProto  {
   option (scalapb.message).extends = "CasperMessageProto";
   repeated bytes hashes = 1 [(scalapb.field).collection_type="List"];
   bytes stateHash       = 2;
+  repeated bytes stateHashes     = 3;  // TODO: this is a hack to make LFS work with the current node code which does merging.
 }
 
 message FinalizedFringeRequestProto {

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -40,14 +40,21 @@ object CasperMessage {
 
 /* Approved block message */
 
-final case class FinalizedFringe(hashes: Seq[BlockHash], stateHash: StateHash)
-    extends CasperMessage {
+final case class FinalizedFringe(
+    hashes: Seq[BlockHash],
+    stateHash: StateHash,
+    stateHashes: Set[StateHash] // TODO: this is a hack to make LFS work with the current node code which does merging.
+) extends CasperMessage {
   def toProto: FinalizedFringeProto =
-    FinalizedFringeProto().withHashes(hashes.toList).withStateHash(stateHash)
+    FinalizedFringeProto()
+      .withHashes(hashes.toList)
+      .withStateHash(stateHash)
+      .withStateHashes(stateHashes.toList)
 }
 
 object FinalizedFringe {
-  def from(f: FinalizedFringeProto): FinalizedFringe = FinalizedFringe(f.hashes, f.stateHash)
+  def from(f: FinalizedFringeProto): FinalizedFringe =
+    FinalizedFringe(f.hashes, f.stateHash, f.stateHashes.toSet)
 }
 
 final case class FinalizedFringeRequest(identifier: String, trimState: Boolean = false)

--- a/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
@@ -9,6 +9,7 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.block.StateHash.StateHash
 import coop.rchain.models.syntax._
 import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.rspace.history.instances.RadixHistory
 
 final case class BlockMetadata(
     blockHash: BlockHash,
@@ -76,7 +77,7 @@ object BlockMetadata {
       validated = false,
       validationFailed = false,
       fringe = Set(),
-      fringeStateHash = protobuf.ByteString.EMPTY,
+      fringeStateHash = RadixHistory.emptyRootHash.toByteString,
       memberOfFringe = none
     )
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/RootRepository.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/RootRepository.scala
@@ -11,7 +11,6 @@ import scala.Function._
 class RootRepository[F[_]: Sync](
     rootsStore: RootsStore[F]
 ) {
-  val unknownRoot = new RuntimeException("unknown root")
 
   def commit(root: Blake2b256Hash): F[Unit] =
     rootsStore.recordRoot(root)
@@ -24,7 +23,7 @@ class RootRepository[F[_]: Sync](
 
   def validateAndSetCurrentRoot(root: Blake2b256Hash): F[Unit] =
     rootsStore.validateAndSetCurrentRoot(root).flatMap {
-      case None    => Sync[F].raiseError[Unit](unknownRoot)
+      case None    => new RuntimeException(s"unknown root $root").raiseError[F, Unit]
       case Some(_) => Applicative[F].pure(())
     }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
@@ -135,8 +135,8 @@ class HistoryRepositorySpec
 
   it should "not allow switching to a not existing root" in withEmptyRepository { repo =>
     repo.reset(zerosBlake).attempt.map {
-      case Left(RuntimeException("unknown root")) => ()
-      case _                                      => fail("Expected a failure")
+      case Left(RuntimeException(_)) => ()
+      case _                         => fail("Expected a failure")
     }
   }
 


### PR DESCRIPTION
## Overview
8a35751ea0599ecb4dbe64dc073f728b8746e7e4 - fix bug that were making node adding blocks top down during LFS pull
85e13b3dc8c8215ab67814037554b7e363f2d8b5 - state cannot have state as empty ByteString

The next 3 commits to make LFS possible with current code that involves merging. It should enable working with single parent mode and LFS. No merging possible.
fb92e4cd87b095a06edd6b43dea583691fa2f19e - do not execute merging code when block is single parent
e302966ce117046a3921c8a45e60b53941484db7 - fix bug when after restoring LFS node is stuck and do not add new blocks
ff032df6a667fbfcf951f26230fb514c427abd47 - node reads bonds map from final state when doing replay, which is some state before LFS when replaying first blocks after LFS. So some additional states are pulled along with LFS state.


<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
