### PR TITLE
Remove old blocks after sync

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
@@ -221,6 +221,11 @@ class NodeSyncing[F[_]
             } yield ()
           }
 
+      // Remove unnecessary blocks from block store (keep last 100)
+      toRemove = heightMap.dropRight(100).flatMap(_._2).toList
+      _        <- BlockStore[F].delete(toRemove)
+      _        <- Log[F].info(s"Removed ${toRemove.size} blocks older then 100 latest dag rows.")
+
       _ <- Log[F].info(s"Blocks for approved state added to DAG.")
     } yield ()
   }


### PR DESCRIPTION
## Overview
A follow up on https://github.com/nzpr/rchain/pull/27 that truncates Block store.
It turned out very hard to pull only blocks that are required for LFS since all code builds metadata by adding blocks one by one. So it is mandatory to pull all blocks and add them to DAG (without validation). 

To truncate block store on LFS, old blocks are just removed from disk after bootstrap.

This PR as referenced one are hacks to enable LFS with current code under round robin propose.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
