### PR TITLE
Same version for circe libraries, downgrade to 0.14.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val fs2Version        = "3.6.1"
   val http4sVersion     = "0.23.6"
   val endpointsVersion  = "1.9.0"
-  val circeVersion      = "0.14.3"
+  val circeVersion      = "0.14.1"
   val enumeratumVersion = "1.5.13"
   val slf4jVersion      = "2.0.7"
   val kamonVersion      = "2.6.0"
@@ -33,7 +33,7 @@ object Dependencies {
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % circeVersion
   val circeGenericExtras  = "io.circe"                   %% "circe-generic-extras"      % circeVersion
   val circeLiteral        = "io.circe"                   %% "circe-literal"             % circeVersion
-  val circeParser         = "io.circe"                   %% "circe-parser"              % "0.14.1"
+  val circeParser         = "io.circe"                   %% "circe-parser"              % circeVersion
   val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.4.0"
   val enumeratum          = "com.beachape"               %% "enumeratum"                % enumeratumVersion
   val endpoints           = "org.endpoints4s"            %% "algebra"                   % endpointsVersion


### PR DESCRIPTION
## Overview
Different versions for circe-parser and other libs made implicit derivation of codecs broken, with node failing with 
```
java.lang.NoClassDefFoundError: io/circe/DecodingFailure$Reason
        at io.circe.generic.decoding.ReprDecoder$.<clinit>(ReprDecoder.scala:23)
        at coop.rchain.node.web.WebApiRoutes$anon$importedDecoder$macro$506$1$$anon$34.apply(WebApiRoutes.scala:100)
        at io.circe.generic.decoding.DerivedDecoder$$anon$1.apply(DerivedDecoder.scala:13)
        at io.circe.Decoder.decodeJson(Decoder.scala:88)
```
when trying to parse DeployRequest.

This PR sets the same version, the newest available for all packages.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
