### PR TITLE
Enforce single parent mode

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
@@ -20,6 +20,7 @@ import coop.rchain.models.{BlockHash => _, _}
 import coop.rchain.sdk.error.FatalError
 import coop.rchain.shared._
 import cats.effect.Temporal
+import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.shared.syntax.sharedSyntaxKeyValueTypedStore
 
 final case class ParsingError(details: String)
@@ -96,6 +97,9 @@ object MultiParentCasper {
                             val (mScope, baseOpt) =
                               MergeScope.fromDag(fringe, prevFringeHashes, dag.childMap, msgMap)
                             for {
+                              _ <- new Exception(
+                                    s"Multiple parents detected. Merging is not supported"
+                                  ).raiseError[F, (Blake2b256Hash, Set[ByteString])]
                               baseStateOpt <- baseOpt.traverse { h =>
                                                BlockStore[F]
                                                  .getUnsafe(h)
@@ -154,6 +158,9 @@ object MultiParentCasper {
                                          msgMap
                                        )
                                      for {
+                                       _ <- new Exception(
+                                             s"Multiple parents detected. Merging is not supported"
+                                           ).raiseError[F, (Blake2b256Hash, Set[ByteString])]
                                        baseStateOpt <- baseOpt.traverse { h =>
                                                         BlockStore[F]
                                                           .getUnsafe(h)
@@ -237,24 +244,26 @@ object MultiParentCasper {
     val blockSender    = block.sender.toByteArray
 
     // TODO: skip creating block index if already in cache
-    val indexBlock = for {
-      mergeableChs <- RuntimeManager[F].loadMergeableChannels(
-                       blockPostState,
-                       blockSender,
-                       block.seqNum
-                     )
-
-      index <- BlockIndex(
-                block.blockHash,
-                block.state.deploys,
-                block.state.systemDeploys,
-                blockPreState.toBlake2b256Hash,
-                blockPostState.toBlake2b256Hash,
-                RuntimeManager[F].getHistoryRepo,
-                mergeableChs
-              )
-      _ = BlockIndex.cache.putIfAbsent(block.blockHash, index)
-    } yield ()
+    // TODO: implement index invalidation when enabling indexing back, otherwise it leaks memory
+    val indexBlock = Sync[F].unit
+//      for {
+//      mergeableChs <- RuntimeManager[F].loadMergeableChannels(
+//                       blockPostState,
+//                       blockSender,
+//                       block.seqNum
+//                     )
+//
+//      index <- BlockIndex(
+//                block.blockHash,
+//                block.state.deploys,
+//                block.state.systemDeploys,
+//                blockPreState.toBlake2b256Hash,
+//                blockPostState.toBlake2b256Hash,
+//                RuntimeManager[F].getHistoryRepo,
+//                mergeableChs
+//              )
+//      _ = BlockIndex.cache.putIfAbsent(block.blockHash, index)
+//    } yield ()
 
     val validationProcessDiag = for {
       // Create block and measure duration

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -176,7 +176,8 @@ object Proposer {
             !(newStateTransition || Stake.isSuperMajority(attestationStake, preStateBondsStake))
           }
         }
-        suppressAttestation <- nothingToFinalize ||^ waitingForSupermajorityToAttest
+        // TODO: revert back. This disables empty blocks.
+        suppressAttestation <- true.pure //nothingToFinalize ||^ waitingForSupermajorityToAttest
         // user deploys
         pooled <- BlockDagStorage[F].pooledDeploys
         pooledOk <- pooled.toList

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -116,7 +116,7 @@ class MultiParentCasperAddBlockSpec extends AnyFlatSpec with Matchers with Inspe
     }
   }
 
-  it should "not allow empty blocks with multiple parents" in effectTest {
+  it should "not allow empty blocks with multiple parents" ignore effectTest {
     TestNode.networkEff(genesis, networkSize = 2).use { nodes =>
       for {
         deployDatas <- (0 to 1).toList

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
@@ -68,7 +68,7 @@ class MultiParentCasperMergeSpec extends AnyFlatSpec with Matchers with Inspecto
     }
   }
 
-  it should "not produce UnusedCommEvent while merging non conflicting blocks in the presence of conflicting ones" in effectTest {
+  it should "not produce UnusedCommEvent while merging non conflicting blocks in the presence of conflicting ones" ignore effectTest {
 
     val registryRho =
       """

--- a/casper/src/test/scala/coop/rchain/casper/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/InterpreterUtilTest.scala
@@ -139,7 +139,7 @@ class InterpreterUtilTest
     }
   }
 
-  it should "merge histories in case of multiple parents" in effectTest {
+  it should "merge histories in case of multiple parents" ignore effectTest {
     val shardId = genesis.shardId
 
     val b1Deploys = Vector(


### PR DESCRIPTION
## Overview
1. Disable block indexing on replay to not leak memory
2. Do not allow attestations
3. Throw exception of multiple parents detected

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
