### PR TITLE
Enable attestation blocks

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -46,20 +46,28 @@ final case class BlockCreator(id: ValidatorIdentity, shardId: String) {
 
     def propose: F[StateTransitionResult] = {
       val rand = BlockRandomSeed.randomGenerator(shardId, blockNum, creatorsPk, preStateHash)
-      // seeds from 0 to deploys.size are used in deploys execution, so system deploy seeds start from the next index
-      val slashSeeds =
-        (0 until toSlash.size).map(_ + deploys.size).map(i => rand.splitByte(i.toByte))
-      val closeSeed = rand.splitByte((deploys.size + toSlash.size).toByte)
 
-      val slashDeploys = toSlash.toList.sorted.zip(slashSeeds).map(SlashDeploy.tupled)
-      val closeDeploy  = CloseBlockDeploy(closeSeed)
+      val slashDeploys = {
+        // seeds from 0 to deploys.size are used in deploys execution, so system deploy seeds start from the next index
+        val slashSeeds =
+          (0 until toSlash.size).map(_ + deploys.size).map(i => rand.splitByte(i.toByte))
+        toSlash.toList.sorted.zip(slashSeeds).map(SlashDeploy.tupled)
+      }
+
+      // Close block using rholang only if rholang state has been adjusted by a block
+      val closeDeployOpt = (slashDeploys.nonEmpty || deploys.nonEmpty).guard[Option].as {
+        val closeSeed = rand.splitByte((deploys.size + toSlash.size).toByte)
+        CloseBlockDeploy(closeSeed)
+      }
+
+      val sysDeploys = closeDeployOpt.map(slashDeploys :+ _).getOrElse(slashDeploys)
 
       BlockDagStorage[F].pooledDeploys
         .map(_.view.filterKeys(deploys.toSet).values.toSeq)
         .flatMap(
           InterpreterUtil.computeDeploysCheckpoint[F](
             _,
-            slashDeploys :+ closeDeploy,
+            sysDeploys,
             rand,
             blockData,
             preStateHash.toByteString

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -163,21 +163,21 @@ object Proposer {
         nothingToFinalize = conflictSet.toList
           .traverse(BlockStore[F].getUnsafe)
           .map(!_.exists(hasDeploys))
-        waitingForSupermajorityToAttest = {
-          val newlySeen = creatorsLatestOpt
-            .map(_.justifications.flatMap(seen) -- parentHashes.flatMap(seen))
-            .getOrElse(Set())
-          newlySeen.toList.traverse(BlockStore[F].getUnsafe).map { newBlocks =>
-            val newStateTransition = newBlocks.exists(hasDeploys)
-            val attestationStake =
-              preStateBonds.view.filterKeys(newBlocks.map(_.sender).toSet).values.toList.sum
-            val preStateBondsStake = preStateBonds.values.toList.sum
-
-            !(newStateTransition || Stake.isSuperMajority(attestationStake, preStateBondsStake))
-          }
-        }
-        // TODO: revert back. This disables empty blocks.
-        suppressAttestation <- true.pure //nothingToFinalize ||^ waitingForSupermajorityToAttest
+        // TODO enable when multi parent
+//        waitingForSupermajorityToAttest = {
+//          val newlySeen = creatorsLatestOpt
+//            .map(_.justifications.flatMap(seen) -- parentHashes.flatMap(seen))
+//            .getOrElse(Set())
+//          newlySeen.toList.traverse(BlockStore[F].getUnsafe).map { newBlocks =>
+//            val newStateTransition = newBlocks.exists(hasDeploys)
+//            val attestationStake =
+//              preStateBonds.view.filterKeys(newBlocks.map(_.sender).toSet).values.toList.sum
+//            val preStateBondsStake = preStateBonds.values.toList.sum
+//
+//            !(newStateTransition || Stake.isSuperMajority(attestationStake, preStateBondsStake))
+//          }
+//        }
+        suppressAttestation <- nothingToFinalize //||^ waitingForSupermajorityToAttest
         // user deploys
         pooled <- BlockDagStorage[F].pooledDeploys
         pooledOk <- pooled.toList

--- a/casper/src/main/scala/coop/rchain/casper/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/InterpreterUtil.scala
@@ -153,14 +153,17 @@ object InterpreterUtil {
         _                  <- Span[F].mark("before-process-pre-state-hash")
         blockData          = BlockData.fromBlock(block)
         withCostAccounting = block.justifications.nonEmpty
-        replayResultF = RuntimeManager[F]
-          .replayComputeState(initialStateHash)(
-            internalDeploys,
-            internalSystemDeploys,
-            rand,
-            blockData,
-            withCostAccounting
-          )
+        replayResultF = if (internalDeploys.isEmpty && internalSystemDeploys.isEmpty)
+          block.postStateHash.asRight[ReplayFailure].pure
+        else
+          RuntimeManager[F]
+            .replayComputeState(initialStateHash)(
+              internalDeploys,
+              internalSystemDeploys,
+              rand,
+              blockData,
+              withCostAccounting
+            )
         replayResult <- retryingOnFailures[Either[ReplayFailure, StateHash]](
                          RetryPolicies.limitRetries(3), {
                            case Right(stateHash) => stateHash == block.postStateHash
@@ -260,14 +263,17 @@ object InterpreterUtil {
       preStateHash: StateHash
   ): F[(StateHash, Seq[ProcessedDeploy], Seq[ProcessedSystemDeploy])] =
     Span[F].trace(ComputeDeploysCheckpointMetricsSource) {
-      for {
-        result <- RuntimeManager[F].computeState(preStateHash)(
-                   deploys,
-                   systemDeploys,
-                   rand,
-                   blockData
-                 )
-        (postStateHash, processedDeploys, processedSystemDeploys) = result
-      } yield (postStateHash, processedDeploys, processedSystemDeploys)
+      if (deploys.isEmpty && systemDeploys.isEmpty) {
+        (preStateHash, Seq.empty[ProcessedDeploy], Seq.empty[ProcessedSystemDeploy]).pure
+      } else
+        for {
+          result <- RuntimeManager[F].computeState(preStateHash)(
+                     deploys,
+                     systemDeploys,
+                     rand,
+                     blockData
+                   )
+          (postStateHash, processedDeploys, processedSystemDeploys) = result
+        } yield (postStateHash, processedDeploys, processedSystemDeploys)
     }
 }

--- a/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
@@ -195,8 +195,8 @@ final case class RuntimeManagerImpl[F[_]: Async: Metrics: Span: Log: Parallel](
   def getActiveValidators(startHash: StateHash): F[Seq[Validator]] =
     spawnRuntime.flatMap(_.getActiveValidators(startHash))
 
-  def computeBonds(hash: StateHash): F[Map[Validator, Long]] =
-    spawnRuntime.flatMap { runtime =>
+  def computeBonds(hash: StateHash): F[Map[Validator, Long]] = {
+    val f = spawnRuntime.flatMap { runtime =>
       def logError(err: Throwable, details: RetryDetails): F[Unit] = details match {
         case WillDelayAndRetry(_, retriesSoFar: Int, _) =>
           Log[F].error(
@@ -218,6 +218,9 @@ final case class RuntimeManagerImpl[F[_]: Async: Metrics: Span: Log: Parallel](
         onError = logError
       )(runtime.computeBonds(hash))
     }
+
+    Cache[F].cached(s"bonds_$hash", f)
+  }
 
   // Executes deploy as user deploy with immediate rollback
   // - InterpreterError is rethrown

--- a/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
@@ -28,6 +28,7 @@ import coop.rchain.rholang.interpreter.{EvaluateResult, ReplayRhoRuntime, RhoRun
 import coop.rchain.rspace
 import coop.rchain.rspace.RSpace.RSpaceStore
 import coop.rchain.rspace.{RSpace, ReplayRSpace}
+import coop.rchain.sdk.cache.Cache
 import coop.rchain.shared.Log
 import coop.rchain.shared.syntax._
 import coop.rchain.store.{KeyValueStoreManager, KeyValueTypedStore}
@@ -71,7 +72,7 @@ trait RuntimeManager[F[_]] {
   def getMergeableStore: MergeableStore[F]
 }
 
-final case class RuntimeManagerImpl[F[_]: Async: Metrics: Span: Log: Parallel](
+final case class RuntimeManagerImpl[F[_]: Async: Metrics: Span: Log: Parallel: Cache](
     space: RhoISpace[F],
     replaySpace: RhoReplayISpace[F],
     historyRepo: RhoHistoryRepository[F],
@@ -261,7 +262,7 @@ object RuntimeManager {
 
   def apply[F[_]](implicit F: RuntimeManager[F]): F.type = F
 
-  def apply[F[_]: Async: Parallel: Metrics: Span: Log](
+  def apply[F[_]: Async: Parallel: Metrics: Span: Log: Cache](
       rSpace: RhoISpace[F],
       replayRSpace: RhoReplayISpace[F],
       historyRepo: RhoHistoryRepository[F],
@@ -280,7 +281,7 @@ object RuntimeManager {
       )
     )
 
-  def apply[F[_]: Async: Parallel: Metrics: Span: Log](
+  def apply[F[_]: Async: Parallel: Metrics: Span: Log: Cache](
       store: RSpaceStore[F],
       mergeableStore: MergeableStore[F],
       mergeableTagName: Par,
@@ -290,7 +291,7 @@ object RuntimeManager {
       _._1
     )
 
-  def createWithHistory[F[_]: Async: Parallel: Metrics: Span: Log](
+  def createWithHistory[F[_]: Async: Parallel: Metrics: Span: Log: Cache](
       store: RSpaceStore[F],
       mergeableStore: MergeableStore[F],
       mergeableTagName: Par,

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
@@ -9,6 +9,7 @@ import coop.rchain.shared.scalatestcontrib._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.{EitherValues, Inspectors}
 import org.scalatest.matchers.should.Matchers
+import coop.rchain.shared.syntax._
 
 class MultiParentCasperDeploySpec
     extends AnyFlatSpec
@@ -30,7 +31,13 @@ class MultiParentCasperDeploySpec
         _                  <- node0.propagateBlock(deploy)(node1)
         _                  <- node0.blockDagStorage.addDeploy(deploy)
         createBlockResult2 <- node1.proposeSync.attempt
-      } yield createBlockResult2.isLeft shouldBe true
+        _                  = createBlockResult2 shouldBe a[Right[_, _]]
+        hash               = createBlockResult2.value
+        deploys            <- node1.blockStore.get1(hash).map(_.map(_.state).map(x => x.deploys))
+      } yield {
+        deploys.isDefined shouldBe true
+        deploys.get should have size 0
+      }
     }
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -26,6 +26,7 @@ import coop.rchain.models.blockImplicits._
 import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import coop.rchain.rspace.syntax._
+import coop.rchain.sdk.cache.Cache
 import coop.rchain.shared.Log
 import coop.rchain.shared.scalatestcontrib._
 import org.scalatest._
@@ -453,6 +454,7 @@ class ValidateTest
 
       val storageDirectory = Files.createTempDirectory(s"hash-set-casper-test-genesis-")
 
+      implicit val c: Cache[IO] = Cache.noOp[IO]
       for {
         kvm    <- mkTestRNodeStoreManager[IO](storageDirectory)
         rStore <- kvm.rSpaceStores

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -19,6 +19,7 @@ import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import coop.rchain.rspace.syntax._
+import coop.rchain.sdk.cache.Cache
 import coop.rchain.shared.PathOps.RichPath
 import coop.rchain.shared.syntax._
 import org.scalatest.EitherValues
@@ -276,6 +277,7 @@ object GenesisTest {
     implicit val noopMetrics: Metrics[F] = new metrics.Metrics.MetricsNOP[F]
     implicit val span: Span[F]           = NoopSpan[F]()
     implicit val log                     = new LogStub[F]
+    implicit val c: Cache[F]             = Cache.noOp[F]
 
     for {
       kvsManager <- Resources.mkTestRNodeStoreManager[F](storePath)

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -39,6 +39,7 @@ import fs2.concurrent.Channel
 import java.nio.file.Path
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 import cats.effect.{Deferred, Ref, Temporal}
+import coop.rchain.sdk.cache.Cache
 
 case class TestNode[F[_]: Async](
     name: String,
@@ -383,6 +384,7 @@ object TestNode {
     implicit val log       = Log.log[F]
     implicit val metricEff = new Metrics.MetricsNOP[F]
     implicit val spanEff   = new NoopSpan[F]
+    implicit val c         = Cache.noOp[F]
     for {
       newStorageDir   <- Resources.copyStorage[F](storageDir)
       kvm             <- Resource.eval(Resources.mkTestRNodeStoreManager(newStorageDir))

--- a/casper/src/test/scala/coop/rchain/casper/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/Resources.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.rholang
 
 import cats.Parallel
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.{Async, IO, Resource, Sync}
 import cats.syntax.all._
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager.rnodeDbMapping
 import coop.rchain.metrics
@@ -9,6 +9,7 @@ import coop.rchain.metrics.{NoopSpan, Span}
 import coop.rchain.models.Par
 import coop.rchain.rholang.Resources.mkTempDir
 import coop.rchain.rspace.syntax._
+import coop.rchain.sdk.cache.Cache
 import coop.rchain.shared.Log
 import coop.rchain.store.LmdbDirStoreManager.mb
 import coop.rchain.store.{KeyValueStoreManager, LmdbDirStoreManager}
@@ -52,6 +53,7 @@ object Resources {
     implicit val log               = Log.log[F]
     implicit val metricsEff        = new metrics.Metrics.MetricsNOP[F]
     implicit val noopSpan: Span[F] = NoopSpan[F]()
+    implicit val c: Cache[F]       = Cache.noOp[F]
 
     for {
       rStore <- kvm.rSpaceStores

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -25,6 +25,7 @@ import java.nio.file.{Files, Path}
 import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable
 import cats.effect.unsafe.implicits.global
+import coop.rchain.sdk.cache.Cache
 
 object GenesisBuilder {
 
@@ -167,6 +168,7 @@ object GenesisBuilder {
     implicit val log: Log.NOPLog[IO]                                = new Log.NOPLog[IO]
     implicit val metricsEff: Metrics[IO]                            = new metrics.Metrics.MetricsNOP[IO]
     implicit val spanEff                                            = NoopSpan[IO]()
+    implicit val c: Cache[IO]                                       = Cache.noOp[IO]
 
     (for {
       kvsManager <- mkTestRNodeStoreManager[IO](storageDirectory)

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -315,3 +315,5 @@ dev {
   # If set, on each propose node will add dummy deploy signed by this key.
   # deployer-private-key =
 }
+
+cache-depth = 1000

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -29,7 +29,8 @@ final case class NodeConf(
     // So its in HOCON notation that should be loaded into `NodeConf` case class.
     // As we need loader to throw an error when unknown HOCON key is met - this field should also
     // be present in the model.
-    defaultDataDir: String
+    defaultDataDir: String,
+    cacheDepth: Int
 )
 
 final case class ProtocolServer(

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -17,9 +17,11 @@ import coop.rchain.node.configuration.NodeConf
 import coop.rchain.node.runtime.NodeCallCtx.NodeCallCtxReader
 import coop.rchain.node.runtime.NodeRuntime._
 import coop.rchain.node.{diagnostics, effects}
+import coop.rchain.sdk.cache.Cache
 import coop.rchain.shared._
 import coop.rchain.shared.syntax._
 import fs2.Stream
+
 import scala.concurrent.duration._
 
 object NodeRuntime {
@@ -172,6 +174,8 @@ class NodeRuntime[F[_]: Parallel: Async: LocalEnvironment: Log] private[node] (
       // RNode key-value store manager / manages LMDB databases
       storeManagerResource <- RNodeKeyValueStoreManager(nodeConf.storage.dataDir).map(_.asResource)
 
+      cache <- Cache.lru[F](nodeConf.cacheDepth)
+
       // Node launch process (Stream) with managed resources
       nodeLaunchResource: Resource[F, Stream[F, Unit]] = {
         implicit val (tr, ca, cc) = (transport, rpConfAsk, rpConnections)
@@ -180,7 +184,8 @@ class NodeRuntime[F[_]: Parallel: Async: LocalEnvironment: Log] private[node] (
           storeManager <- storeManagerResource
 
           // Running node as a Stream
-          result <- Resource.eval(
+          result <- Resource.eval {
+                     implicit val c: Cache[F] = cache
                      Setup.setupNodeProgram[F](
                        storeManager,
                        rpConnections,
@@ -189,7 +194,7 @@ class NodeRuntime[F[_]: Parallel: Async: LocalEnvironment: Log] private[node] (
                        blockRetriever,
                        nodeConf
                      )
-                   )
+                   }
           (nodeLaunch, routingMsgQueue, grpcServices, webApi, adminWebApi, reportRoutes) = result
 
           // Build network resources

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -45,9 +45,10 @@ import coop.rchain.store.KeyValueStoreManager
 import fs2.Stream
 import fs2.concurrent.Channel
 import cats.effect.{Deferred, Ref, Temporal}
+import coop.rchain.sdk.cache.Cache
 
 object Setup {
-  def setupNodeProgram[F[_]: Async: Parallel: LocalEnvironment: TransportLayer: NodeDiscovery: Log: Metrics](
+  def setupNodeProgram[F[_]: Async: Parallel: LocalEnvironment: TransportLayer: NodeDiscovery: Log: Metrics: Cache](
       storeManager: KeyValueStoreManager[F],
       rpConnections: ConnectionsCell[F],
       rpConfAsk: ApplicativeAsk[F, RPConf],

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -221,7 +221,8 @@ class ConfigMapperSpec extends AnyFunSuite with Matchers {
         zipkin = true,
         sigar = true
       ),
-      dev = DevConf(deployerPrivateKey = None)
+      dev = DevConf(deployerPrivateKey = None),
+      cacheDepth = 1000
     )
     config shouldEqual expectedConfig
   }

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -140,7 +140,8 @@ class HoconConfigurationSpec extends AnyFunSuite with Matchers {
         zipkin = false,
         sigar = false
       ),
-      dev = DevConf(deployerPrivateKey = None)
+      dev = DevConf(deployerPrivateKey = None),
+      cacheDepth = 1000
     )
     config shouldEqual expectedConfig
   }

--- a/sdk/src/main/scala/coop/rchain/sdk/cache/Cache.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/cache/Cache.scala
@@ -2,7 +2,6 @@ package coop.rchain.sdk.cache
 
 import cats.effect.{Async, Deferred, Ref}
 import cats.syntax.all._
-import coop.rchain.sdk.error.FatalError
 
 import scala.collection.mutable
 

--- a/sdk/src/main/scala/coop/rchain/sdk/cache/Cache.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/cache/Cache.scala
@@ -1,0 +1,43 @@
+package coop.rchain.sdk.cache
+
+import cats.effect.{Async, Deferred, Ref}
+import cats.syntax.all._
+import coop.rchain.sdk.error.FatalError
+
+import scala.collection.mutable
+
+trait Cache[F[_]] {
+  def cached[A](k: String, compute: F[A]): F[A]
+}
+
+object Cache {
+  def apply[F[_]](implicit cache: Cache[F]): Cache[F] = cache
+
+  def noOp[F[_]]: Cache[F] = new Cache[F] {
+    override def cached[A](k: String, compute: F[A]): F[A] = compute
+  }
+
+  /** LRU cache limited by number of keys. */
+  def lru[F[_]: Async](size: Int): F[Cache[F]] =
+    Ref.of(new mutable.LinkedHashMap[String, Deferred[F, AnyVal]]).map { st =>
+      new Cache[F] {
+        override def cached[A](k: String, compute: F[A]): F[A] =
+          for {
+            newDef <- Deferred[F, A]
+            d <- st.modify { st =>
+                  st.get(k)
+                    .map { existing =>
+                      (st, existing.asInstanceOf[Deferred[F, A]])
+                    }
+                    .getOrElse {
+                      val newSt = st.addOne(k -> newDef.asInstanceOf[Deferred[F, AnyVal]])
+                      val s     = if (newSt.sizeIs > size) newSt.drop(newSt.size - size) else newSt
+                      (s, newDef)
+                    }
+                }
+            _ <- compute.flatMap(d.complete).whenA(newDef == d)
+            r <- d.get
+          } yield r
+      }
+    }
+}

--- a/sdk/src/test/scala/coop/rchain/sdk/CacheSpec.scala
+++ b/sdk/src/test/scala/coop/rchain/sdk/CacheSpec.scala
@@ -1,0 +1,41 @@
+package coop.rchain.sdk
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import coop.rchain.sdk.cache.Cache
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CacheSpec extends AnyFlatSpec with Matchers {
+
+  it should "cache a value" in {
+    val c: Cache[IO] = Cache.lru[IO](10).unsafeRunSync()
+    var counter      = 0
+    val f = IO.delay {
+      counter += 1
+      0
+    }
+
+    val p = c.cached("key", f) >> c.cached("key", f)
+
+    p.unsafeRunSync() shouldBe 0
+    counter shouldBe 1
+  }
+
+  it should "remove oldest records once hit size limit" in {
+    val c: Cache[IO] = Cache.lru[IO](2).unsafeRunSync()
+    var counter      = 0
+    val f = IO.delay {
+      counter += 1
+      0
+    }
+
+    val p =
+      c.cached("key1", f) >> c.cached("key2", f) >> c.cached("key3", f) >>
+        // this call should also execute f, since cache size is 2 and first call on key1 is removed by now
+        c.cached("key1", f)
+
+    p.unsafeRunSync() shouldBe 0
+    counter shouldBe 4
+  }
+}


### PR DESCRIPTION
## Overview
This enables ability to mint empty block that serve as attestation.

Previous behaviour
When no deploys to put in a block propose request is rejected.

New behaviour:
When no deploys to put in a block propose request is accepted IIF there are deploys in a conflict set. Block with no deploys is minted.

To speed up attestation creation, caching is enabled for querying of the bonds map on a state hash. Since subsequent attestations share the same hash of a tuple space, this caching is very effective.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
