### PR TITLE
Make bonds cache use textual representation of the state hash as key

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
@@ -220,7 +220,7 @@ final case class RuntimeManagerImpl[F[_]: Async: Metrics: Span: Log: Parallel: C
       )(runtime.computeBonds(hash))
     }
 
-    Cache[F].cached(s"bonds_$hash", f)
+    Cache[F].cached(s"bonds_${hash.show}", f)
   }
 
   // Executes deploy as user deploy with immediate rollback


### PR DESCRIPTION
## Overview
Rendering a byte string as a hash key defeats the purpose of caching since its produces unique string. So this PR changes key to be Base16 string.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
