### PR TITLE
Quick reboot

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
@@ -1,34 +1,37 @@
 package coop.rchain.blockstorage.dag
 
 import cats.Monad
-import cats.effect.Sync
+import cats.effect.{Ref, Sync}
 import cats.syntax.all._
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.BlockMetadata
+import coop.rchain.sdk.error.FatalError
 import coop.rchain.shared.Log
 import coop.rchain.shared.syntax._
 import coop.rchain.store.KeyValueTypedStore
 
 import scala.collection.immutable.SortedMap
-import cats.effect.Ref
 
 object BlockMetadataStore {
   def apply[F[_]: Sync: Log](
-      blockMetadataStore: KeyValueTypedStore[F, BlockHash, BlockMetadata]
+      blockMetadataStore: KeyValueTypedStore[F, BlockHash, BlockMetadata],
+      lfsSetStore: KeyValueTypedStore[F, BlockHash, Unit]
   ): F[BlockMetadataStore[F]] =
     for {
-      _ <- Log[F].info("Building in-memory blockMetadataStore.")
+      lfsSet <- lfsSetStore.toMap.map(_.keySet)
+      _      <- Log[F].info(s"Loading blocks metadata (${lfsSet.size} blocks).")
       // Iterate over block metadata store and collect info for in-memory cache
-      blockInfoMap <- blockMetadataStore.collect {
-                       case (hash, metaData) =>
-                         (hash, blockMetadataToInfo(metaData()))
-                     }
-      _           <- Log[F].info("Reading data from blockMetadataStore done.")
-      dagState    = recreateInMemoryState(blockInfoMap.toMap)
+      blockInfoMap <- blockMetadataStore
+                       .get(lfsSet.toList)
+                       .map(_.flatten.map(x => x.blockHash -> blockMetadataToInfo(x)).toMap)
+      _ <- new FatalError(s"Missing block metadata required").raiseError
+            .whenA(blockInfoMap.size != lfsSet.size)
+      _           <- Log[F].info("Loading blocks metadata done.")
+      dagState    = recreateInMemoryState(blockInfoMap)
       _           <- Log[F].info("Successfully built in-memory blockMetadataStore.")
       dagStateRef <- Ref[F].of(dagState)
-    } yield new BlockMetadataStore[F](blockMetadataStore, dagStateRef)
+    } yield new BlockMetadataStore[F](blockMetadataStore, lfsSetStore, dagStateRef)
 
   final case class BlockMetadataStoreInconsistencyError(message: String) extends Exception(message)
 
@@ -48,6 +51,7 @@ object BlockMetadataStore {
 
   class BlockMetadataStore[F[_]: Monad](
       private val store: KeyValueTypedStore[F, BlockHash, BlockMetadata],
+      val lfsSetStore: KeyValueTypedStore[F, BlockHash, Unit], // store for latest messages
       private val dagState: Ref[F, DagState]
   ) {
     def add(block: BlockMetadata): F[Unit] =
@@ -61,6 +65,9 @@ object BlockMetadataStore {
 
         // Update persistent block metadata store
         _ <- store.put(block.blockHash, block)
+
+        // add to LFS set. It will be removed when GC event happens.
+        _ <- lfsSetStore.put(block.blockHash, ())
       } yield ()
 
     def get(hash: BlockHash): F[Option[BlockMetadata]] = store.get1(hash)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagMessageState.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagMessageState.scala
@@ -2,6 +2,7 @@ package coop.rchain.blockstorage.dag
 
 import cats.syntax.all._
 import coop.rchain.blockstorage.syntax._
+import coop.rchain.sdk.dag.View
 
 object DagMessageState {
   def apply[M: Ordering, S: Ordering](): DagMessageState[M, S] =
@@ -34,8 +35,7 @@ final case class DagMessageState[M: Ordering, S: Ordering](
     val newFringeIds = newFringe.map(_.id)
 
     // Seen messages are all seen from justifications combined
-    val seenByParents = justifications.flatMap(_.seen)
-    val newSeen       = seenByParents + id
+    val newSeen = View.compute[S, Message[M, S]](justifications, _.sender, _.senderSeq, _.seen)
 
     // Create message, an immutable object with all fields calculated
     val justificationKeys = justifications.map(_.id)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
@@ -52,8 +52,10 @@ final case class DagRepresentation(
         .toMap
     )
     val seenByFringe = Monoid[View[Validator]].combineAll(latestFringe.map(_.seen) + fringeAsSeen)
-    val msgMeta      = dagMessageState.msgMap.getUnsafe(blockHash)
-    seenByFringe.seen.get(msgMeta.sender).exists(_.contains(msgMeta.senderSeq.toInt))
+    val msgMetaOpt   = dagMessageState.msgMap.get(blockHash)
+    msgMetaOpt.exists { msgMeta =>
+      seenByFringe.seen.get(msgMeta.sender).exists(_.contains(msgMeta.senderSeq.toInt))
+    }
   }
 
   def topoSort(

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
@@ -1,11 +1,12 @@
 package coop.rchain.blockstorage.dag
 
+import cats.kernel.Monoid
 import cats.syntax.all._
-import coop.rchain.blockstorage.syntax._
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.syntax._
 import coop.rchain.models.{BlockHash, FringeData}
+import coop.rchain.sdk.dag.View
 
 import scala.collection.immutable.SortedMap
 
@@ -26,11 +27,11 @@ final case class DagRepresentation(
     heightMap: SortedMap[Long, Set[BlockHash]],
     dagMessageState: DagMessageState[BlockHash, Validator],
     // In-memory cache for fringe data store (it should only include working range of blocks needed for finalization)
-    fringeStates: Map[Set[BlockHash], FringeData]
+    fringeStates: Map[Set[BlockHash], FringeData],
+    // Index for block hashes by validator and sequence number. Its a set to accommodate equivocations
+    hashLookup: Map[(Validator, Long), Set[BlockHash]]
 ) {
   lazy val latestFringe: Set[Message[BlockHash, Validator]] = dagMessageState.latestFringe
-
-  lazy val finalizedBlocksSet: Set[BlockHash] = latestFringe.flatMap(_.seen)
 
   lazy val latestBlockNumber: Long = heightMap.lastOption.map { case (h, _) => h + 1 }.getOrElse(0L)
 
@@ -43,7 +44,17 @@ final case class DagRepresentation(
 
   def children(blockHash: BlockHash): Option[Set[BlockHash]] = childMap.get(blockHash)
 
-  def isFinalized(blockHash: BlockHash): Boolean = finalizedBlocksSet.contains(blockHash)
+  import coop.rchain.sdk.syntax.all._
+  def isFinalized(blockHash: BlockHash): Boolean = {
+    val fringeAsSeen = View(
+      latestFringe
+        .map(x => x.sender -> Range.inclusive(x.senderSeq.toInt, x.senderSeq.toInt))
+        .toMap
+    )
+    val seenByFringe = Monoid[View[Validator]].combineAll(latestFringe.map(_.seen) + fringeAsSeen)
+    val msgMeta      = dagMessageState.msgMap.getUnsafe(blockHash)
+    seenByFringe.seen.get(msgMeta.sender).exists(_.contains(msgMeta.senderSeq.toInt))
+  }
 
   def topoSort(
       startBlockNumber: Long,

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/Finalizer.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/Finalizer.scala
@@ -3,6 +3,7 @@ package coop.rchain.blockstorage.dag
 import cats.syntax.all._
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.sdk.consensus.Stake
+import coop.rchain.sdk.dag.View
 
 import scala.collection.compat.immutable.LazyList
 
@@ -29,7 +30,7 @@ final case class Message[M, S](
     parents: Set[M],
     fringe: Set[M],
     // Cache of seen message ids
-    seen: Set[M]
+    seen: View[S]
 ) {
   override def hashCode(): Int = this.id.hashCode()
 }
@@ -101,8 +102,10 @@ final case class Finalizer[M, S](msgMap: Map[M, Message[M, S]]) {
               .map(msgMap)
               .map { p =>
                 // Find if next layer message is seen from any parent message
-                val selfMsgs     = p +: selfParents(p, finalized)
-                val seenByParent = selfMsgs.exists(_.seen.contains(minMsg.id))
+                val selfMsgs = p +: selfParents(p, finalized)
+                val seenByParent = selfMsgs.exists(
+                  _.seen.seen.get(minMsg.sender).exists(_.contains(minMsg.senderSeq.toInt))
+                )
                 (p.sender, seenByParent)
               }
               .filter(_._2)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/MessageMapSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/MessageMapSyntax.scala
@@ -1,6 +1,9 @@
 package coop.rchain.blockstorage.dag
 
+import cats.kernel.Monoid
 import cats.syntax.all._
+import coop.rchain.sdk.dag.View
+import coop.rchain.sdk.dag.View.IncludePolicy
 import coop.rchain.sdk.syntax.all.mapSyntax
 
 trait MessageMapSyntax {
@@ -17,10 +20,35 @@ final class MessageMapSyntaxOps[M, S](private val msgMap: Map[M, Message[M, S]])
   /**
     * Gets the slice of messages between upper and lower bound (including upper bound messages)
     */
-  def between(upperBound: Set[Msg], lowerBound: Set[Msg]): Set[Msg] = {
-    val upperSeen = upperBound.flatMap(_.seen.map(msgMap))
-    val lowerSeen = lowerBound.flatMap(_.seen.map(msgMap))
-    upperSeen -- lowerSeen
+  def between(
+      upperBound: Set[M],
+      lowerBound: Set[M],
+      lookup: (S, Long) => M,
+      includePolicy: IncludePolicy
+  ): Set[M] = {
+    val upperAsSeen = View[S](
+      upperBound
+        .map(msgMap.getUnsafe)
+        .map(x => x.sender -> Range.inclusive(x.senderSeq.toInt, x.senderSeq.toInt))
+        .toMap
+    )
+    val bottomAsSeen = View[S](
+      lowerBound
+        .map(msgMap.getUnsafe)
+        .map(x => x.sender -> Range.inclusive(x.senderSeq.toInt, x.senderSeq.toInt))
+        .toMap
+    )
+    View
+      .diff(
+        Monoid[View[S]].combineAll(upperBound.map(msgMap.getUnsafe).map(_.seen) + upperAsSeen),
+        Monoid[View[S]].combineAll(lowerBound.map(msgMap.getUnsafe).map(_.seen) + bottomAsSeen),
+        includePolicy
+      )
+      .seen
+      .iterator
+      .flatMap { case (v, r) => r.map(_.toLong).map(v -> _) }
+      .map(lookup.tupled)
+      .toSet
   }
 
   /**

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
@@ -17,11 +17,13 @@ import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.syntax._
 import coop.rchain.models.{BlockHash => _, _}
-import coop.rchain.sdk.error.FatalError
-import coop.rchain.shared._
-import cats.effect.Temporal
 import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.sdk.error.FatalError
+import coop.rchain.sdk.syntax.all.mapSyntax
+import coop.rchain.shared._
 import coop.rchain.shared.syntax.sharedSyntaxKeyValueTypedStore
+
+import scala.concurrent.duration.DurationInt
 
 final case class ParsingError(details: String)
 
@@ -95,11 +97,20 @@ object MultiParentCasper {
       newFringeResult <- newFringeHashes.traverse { fringe =>
                           val mergeFringe = {
                             val (mScope, baseOpt) =
-                              MergeScope.fromDag(fringe, prevFringeHashes, dag.childMap, msgMap)
+                              MergeScope.fromDag(
+                                fringe,
+                                prevFringeHashes,
+                                dag.childMap,
+                                msgMap,
+                                dag.hashLookup.getUnsafe
+                              )
                             for {
-                              _ <- new Exception(
-                                    s"Multiple parents detected. Merging is not supported"
-                                  ).raiseError[F, (Blake2b256Hash, Set[ByteString])]
+                              _ <- Log[F].error(
+                                    s"Multiple parents detected for a message (${fringe
+                                      .map(_.toHexString.take(8))}). Merging is not supported"
+                                  )
+                              // Sleep instead iof throwing exception to be able to query node.
+                              _ <- Sync[F].sleep(Int.MaxValue.seconds)
                               baseStateOpt <- baseOpt.traverse { h =>
                                                BlockStore[F]
                                                  .getUnsafe(h)
@@ -149,18 +160,22 @@ object MultiParentCasper {
                                        .getUnsafe(parent)
                                        .map(_.postStateHash)
                                        .map(x => (x.toBlake2b256Hash, Set.empty[ByteString]))
-                                   case _ =>
+                                   case ps =>
                                      val (mScope, baseOpt) =
                                        MergeScope.fromDag(
                                          parentHashes,
                                          newFringe,
                                          dag.childMap,
-                                         msgMap
+                                         msgMap,
+                                         dag.hashLookup.getUnsafe
                                        )
                                      for {
-                                       _ <- new Exception(
-                                             s"Multiple parents detected. Merging is not supported"
-                                           ).raiseError[F, (Blake2b256Hash, Set[ByteString])]
+                                       _ <- Log[F].error(
+                                             s"Multiple parents detected for a message (${ps
+                                               .map(_.toHexString.take(8))}). Merging is not supported"
+                                           )
+                                       // Sleep instead iof throwing exception to be able to query node.
+                                       _ <- Sync[F].sleep(Int.MaxValue.seconds)
                                        baseStateOpt <- baseOpt.traverse { h =>
                                                         BlockStore[F]
                                                           .getUnsafe(h)
@@ -206,7 +221,8 @@ object MultiParentCasper {
 
     val validationProcess: EitherT[F, (BlockMetadata, InvalidBlock), BlockMetadata] =
       for {
-        _                                <- validateSummary
+        _ <- validateSummary
+        // compute view
         _                                <- EitherT.liftF(Span[F].mark("post-validation-block-summary"))
         validated                        <- EitherT.liftF(InterpreterUtil.validateBlockCheckpoint(block))
         (blockMetadata, validatedResult) = validated

--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -211,7 +211,7 @@ object GraphGenerator {
     val fringes = blocks
       .foldLeft(initFringeMap) {
         case (acc, b) =>
-          val fringe     = b.fringe.map(blockMap)
+          val fringe     = b.fringe.flatMap(blockMap.get)
           val seenFringe = acc.getOrElse(fringe, Set())
           acc + ((fringe, seenFringe + b))
       }

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
@@ -125,15 +125,18 @@ final case class BlockReceiverState[MId: Show] private (
     * @return next blocks with validated dependencies
     */
   def finished(id: MId, parents: Set[MId]): (BlockReceiverState[MId], Set[MId]) = {
-    val parentsInState = blocksSt.contains(id)
-    val isReceived = receiveSt.get(id).collect {
-      case EndStoreBlock     =>
-      case PendingValidation =>
-    }
+    val inState = blocksSt.contains(id)
+    val isReceived = receiveSt
+      .get(id)
+      .collect {
+        case EndStoreBlock     =>
+        case PendingValidation =>
+      }
+      .isDefined
     // To finish block it must be present in the state (parents relations and at least stored)
     assert(
-      parentsInState && isReceived.isDefined,
-      s"Calling finished on unexpected block hash ${id.show}."
+      inState && isReceived,
+      s"Calling finished on unexpected block hash ${id.show} (inState $inState isReceived $isReceived)."
     )
 
     // Update blocks state

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -20,6 +20,8 @@ import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.syntax._
 import coop.rchain.sdk.consensus.Stake
+import coop.rchain.sdk.dag.View
+import coop.rchain.sdk.dag.View.IncludeTop
 import coop.rchain.sdk.error.FatalError
 import coop.rchain.shared.syntax._
 import coop.rchain.shared.Log
@@ -156,10 +158,15 @@ object Proposer {
         changeEpoch = nextBlockNum % epochLength == 0
         // attestation
         // no need to attest if nothing meaningful to finalize.
-        dag         <- BlockDagStorage[F].getRepresentation
-        seen        = dag.dagMessageState.msgMap(_: BlockHash).seen
-        conflictSet = parentHashes.flatMap(seen) -- preState.fringe.flatMap(seen)
-        hasDeploys  = (b: BlockMessage) => b.state.systemDeploys.nonEmpty || b.state.deploys.nonEmpty
+        dag <- BlockDagStorage[F].getRepresentation
+        conflictSet = dag.dagMessageState.msgMap
+          .between(
+            parentHashes,
+            preState.fringe,
+            (v, sN) => dag.hashLookup.getUnsafe(v -> sN).head,
+            IncludeTop
+          )
+        hasDeploys = (b: BlockMessage) => b.state.systemDeploys.nonEmpty || b.state.deploys.nonEmpty
         nothingToFinalize = conflictSet.toList
           .traverse(BlockStore[F].getUnsafe)
           .map(!_.exists(hasDeploys))

--- a/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
+++ b/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
@@ -1,6 +1,8 @@
 package coop.rchain.casper.dag
 
-import cats.effect.Async
+import cats.effect.std.Semaphore
+import cats.effect.{Async, Ref, Sync}
+import cats.kernel.Monoid
 import cats.syntax.all._
 import cats.{Monad, Show}
 import coop.rchain.blockstorage._
@@ -22,14 +24,15 @@ import coop.rchain.models.syntax._
 import coop.rchain.models.{BlockMetadata, FringeData}
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.hashing.Blake2b256Hash.codecBlake2b256Hash
+import coop.rchain.sdk.dag.View
+import coop.rchain.sdk.dag.View.{IncludeBottom, IncludeTop}
 import coop.rchain.shared.Log
 import coop.rchain.shared.syntax._
 import coop.rchain.store.{KeyValueStoreManager, KeyValueTypedStore}
 import fs2.Stream
 
 import scala.collection.concurrent.TrieMap
-import cats.effect.Ref
-import cats.effect.std.Semaphore
+import scala.collection.immutable.SortedMap
 
 final class BlockDagKeyValueStorage[F[_]: Async: Log] private (
     representationState: Ref[F, DagRepresentation],
@@ -60,7 +63,8 @@ final class BlockDagKeyValueStorage[F[_]: Async: Log] private (
         deployHashes = block.state.deploys.map(_.deploy.sig)
         _            <- deployIndex.put(deployHashes.map(_ -> block.blockHash))
 
-        dagState <- representationState.get.map(_.dagMessageState)
+        dag      <- representationState.get
+        dagState = dag.dagMessageState
 
         // Store fringe data
         fringeHash = FringeData.fringeHash(blockMetadata.fringe)
@@ -68,13 +72,22 @@ final class BlockDagKeyValueStorage[F[_]: Async: Log] private (
         justificationsMsgs = blockMetadata.justifications.map(dagState.msgMap)
         prevFringeMsgs     = dagState.msgMap.latestFringe(justificationsMsgs)
         fringeMsgs         = blockMetadata.fringe.map(dagState.msgMap)
-        fringeDiff         = fringeMsgs.flatMap(_.seen) -- prevFringeMsgs.flatMap(_.seen)
+        fringeDiff = View
+          .diff(
+            Monoid[View[Validator]].combineAll(fringeMsgs.map(_.seen)),
+            Monoid[View[Validator]].combineAll(prevFringeMsgs.map(_.seen)),
+            IncludeTop
+          )
+          .seen
+          .map { case (v, r) => r.map(_.toLong).map(v -> _) }
+          .flatten
 
+        fringeDiffHashes = fringeDiff.toList.flatMap(dag.hashLookup).toSet
         // Fringe data object to store
         fringeData = FringeData(
           fringeHash,
           fringe = blockMetadata.fringe,
-          fringeDiff = fringeDiff,
+          fringeDiff = fringeDiffHashes,
           stateHash = blockMetadata.fringeStateHash.toBlake2b256Hash,
           rejectedDeploys = block.rejectedDeploys,
           rejectedBlocks = block.rejectedBlocks,
@@ -84,7 +97,7 @@ final class BlockDagKeyValueStorage[F[_]: Async: Log] private (
         _ <- fringeDataStore.put(fringeHash, fringeData)
 
         // Update block metadata members of finalized fringe
-        fringeDiffMetas        <- fringeDiff.toList.traverse(blockMetadataIndex.getUnsafe)
+        fringeDiffMetas        <- fringeDiffHashes.toList.traverse(blockMetadataIndex.getUnsafe)
         fringeDiffMetasUpdated = fringeDiffMetas.map(_.copy(memberOfFringe = fringeHash.some))
         _                      <- fringeDiffMetasUpdated.traverse(blockMetadataIndex.add)
 
@@ -95,8 +108,13 @@ final class BlockDagKeyValueStorage[F[_]: Async: Log] private (
         dag <- representationState.updateAndGet { dr =>
                 // Update DAG messages state
                 val dagMsgSt       = dr.dagMessageState
-                val msg            = messageFromBlockMetadata(blockMetadata, dagMsgSt.msgMap, heightMap)
+                val msg            = messageFromBlockMetadata(blockMetadata)
                 val newDagMsgState = dagMsgSt.insertMsg(msg)
+
+                val newHashLookup = dr.hashLookup.updated(
+                  (msg.sender, msg.senderSeq),
+                  dr.hashLookup.getOrElse((msg.sender, msg.senderSeq), Set()) + msg.id
+                )
 
                 // Update fringe data cache
                 // TODO: remove out of reach records (not needed for further finalization)
@@ -108,16 +126,23 @@ final class BlockDagKeyValueStorage[F[_]: Async: Log] private (
                   childMap,
                   heightMap,
                   newDagMsgState,
-                  fringeStates = newFringes
+                  fringeStates = newFringes,
+                  hashLookup = newHashLookup
                 )
               }
 
         // attempt to prune only when sender is the only outsider
-        lowestFringe            = dagState.msgMap.lowestFringe(dagState.latestMsgs).map(_.id)
-        outsiders               = dagState.latestMsgs.filter(_.fringe == lowestFringe).map(_.sender)
-        senderIsTheOnlyOutsider = outsiders == Set(blockMetadata.sender)
-        shouldPrune             = fringeDiff.nonEmpty && senderIsTheOnlyOutsider
-        _                       <- pruneDiff(dag.dagMessageState, dagState, childMap).whenA(shouldPrune)
+        // (this means all justifications already advanced the fringe compared to self justification)
+        // so no new valid (non equivocating) messages will reference what is about to be pruned
+        lowestFringe = dagState.msgMap.lowestFringe(dagState.latestMsgs).map(_.id)
+        outsiders    = dagState.latestMsgs.filter(_.fringe == lowestFringe).map(_.sender)
+        shouldPrune  = outsiders == Set(blockMetadata.sender)
+        _ <- pruneDiff(
+              dag.dagMessageState,
+              dagState,
+              childMap,
+              (v, sN) => dag.hashLookup.getUnsafe(v -> sN).head
+            ).whenA(shouldPrune)
 
         _ <- removeExpiredFromPool(deployStore, dag).map(
               _.map((_, ())).foreach((expiredMap.update _).tupled)
@@ -152,14 +177,17 @@ final class BlockDagKeyValueStorage[F[_]: Async: Log] private (
   def pruneDiff(
       newState: DagMessageState[BlockHash, Validator],
       curState: DagMessageState[BlockHash, Validator],
-      childMap: Map[BlockHash, Set[BlockHash]]
+      childMap: Map[BlockHash, Set[BlockHash]],
+      lookup: (Validator, Long) => BlockHash
   ): F[Unit] = {
-    val newLPF  = dbPruneFringe(newState, childMap)
-    val curLPF  = dbPruneFringe(curState, childMap)
-    val toPrune = (newState.msgMap.between(newLPF, curLPF) ++ curLPF).map(_.id)
+    val newLPF = dbPruneFringe(newState, childMap)
+    val curLPF = dbPruneFringe(curState, childMap)
+    val toPrune = newState.msgMap.between(newLPF.map(_.id), curLPF.map(_.id), lookup, IncludeBottom) ++
+      curLPF.map(_.id)
 
-    toPrune.toList.foreach(BlockIndex.cache.remove)
-    Log[F].info(s"Pruned ${toPrune.size} merging indices, new size: ${BlockIndex.cache.size}")
+    Sync[F].delay(toPrune.toList.foreach(BlockIndex.cache.remove)) *>
+      blockMetadataIndex.lfsSetStore.delete(toPrune.toList) *>
+      Log[F].info(s"Pruned ${toPrune.size} blocks, new index size: ${BlockIndex.cache.size}")
   }
 
   override def lookup(blockHash: BlockHash): F[Option[BlockMetadata]] =
@@ -184,13 +212,15 @@ object BlockDagKeyValueStorage {
 
   private final case class DagStores[F[_]](
       metadata: BlockMetadataStore[F],
-      metadataDb: KeyValueTypedStore[F, BlockHash, BlockMetadata],
+      lfsSet: KeyValueTypedStore[F, BlockHash, Unit], // set of blocks metadata required to start the node
       fringeDataDb: KeyValueTypedStore[F, Blake2b256Hash, FringeData],
       deploys: KeyValueTypedStore[F, DeployId, BlockHash],
       deployPool: KeyValueTypedStore[F, DeployId, Signed[DeployData]]
   )
 
-  private def createStores[F[_]: Async: Log: Metrics](kvm: KeyValueStoreManager[F]) = {
+  private def createStores[F[_]: Async: Log: Metrics](
+      kvm: KeyValueStoreManager[F]
+  ): F[DagStores[F]] = {
     implicit val kvm_ = kvm
     for {
       // Block metadata map
@@ -199,7 +229,14 @@ object BlockDagKeyValueStorage {
                           codecBlockHash,
                           codecBlockMetadata
                         )
-      blockMetadataStore <- BlockMetadataStore[F](blockMetadataDb)
+
+      lfsDb <- KeyValueStoreManager[F].database[BlockHash, Unit](
+                "lfs-set",
+                codecBlockHash,
+                scodec.Codec[Unit]
+              )
+
+      blockMetadataStore <- BlockMetadataStore[F](blockMetadataDb, lfsDb)
 
       // Fringe data map
       fringeDataDb <- KeyValueStoreManager[F].database[Blake2b256Hash, FringeData](
@@ -223,7 +260,7 @@ object BlockDagKeyValueStorage {
                      )
     } yield DagStores(
       blockMetadataStore,
-      blockMetadataDb,
+      lfsDb,
       fringeDataDb,
       deployIndexDb,
       deployPoolDb
@@ -243,35 +280,41 @@ object BlockDagKeyValueStorage {
           dagSet    <- metadata.dagSet
           childMap  <- metadata.childMapData
           heightMap <- metadata.heightMap
+          lfsSet    <- metadata.lfsSetStore.toMap.map(_.keySet)
 
           // Fill message map from BlockMetadata
-          // TODO: include only non-finalized block
           dmsSt <- Ref.of(DagMessageState[BlockHash, Validator]())
           fsSt  <- Ref.of(Map[Set[BlockHash], FringeData]())
-          i     = heightMap.values.flatten.iterator
-          initMsgMapJob = Stream.fromIterator(i, 1).evalMap { hash =>
+          hlSt  <- Ref.of(Map[(Validator, Long), Set[BlockHash]]())
+
+          initMsgMapJob = Stream.fromIterator(lfsSet.iterator, 1).evalMap { hash =>
             for {
               ds     <- dmsSt.get
               fs     <- fsSt.get
+              hl     <- hlSt.get
               msgMap = ds.msgMap
               updateMessage = for {
                 block <- metadata.getUnsafe(hash)
-                msg   = messageFromBlockMetadata(block, msgMap, heightMap)
+                msg   = messageFromBlockMetadata(block)
                 newDs = ds.insertMsg(msg)
 
                 fringeDataCached = fs.contains(msg.fringe)
                 newFs <- if (!fringeDataCached) {
-                          implicit val showHash = Show.show[Blake2b256Hash](_.bytes.toHex)
-                          val fringeHash        = FringeData.fringeHash(msg.fringe)
+                          implicit val showHash: Show[Blake2b256Hash] =
+                            Show.show[Blake2b256Hash](_.bytes.toHex)
+                          val fringeHash = FringeData.fringeHash(msg.fringe)
                           stores.fringeDataDb
                             .getUnsafe(fringeHash)
                             .map(fd => fs + ((msg.fringe, fd)))
                         } else {
                           fs.pure[F]
                         }
+                newHl = hl + ((msg.sender, msg.senderSeq) -> (hl
+                  .getOrElse((msg.sender, msg.senderSeq), Set.empty) + hash))
 
                 _ <- dmsSt.set(newDs)
                 _ <- fsSt.set(newFs)
+                _ <- hlSt.set(newHl)
               } yield ()
 
               // Check if already created
@@ -283,7 +326,15 @@ object BlockDagKeyValueStorage {
           _            <- initMsgMapJob.compile.drain
           dagMsgsState <- dmsSt.get
           fringeStates <- fsSt.get
-        } yield DagRepresentation(dagSet, childMap, heightMap, dagMsgsState, fringeStates)
+          hashLookup   <- hlSt.get
+        } yield DagRepresentation(
+          dagSet,
+          childMap,
+          heightMap,
+          dagMsgsState,
+          fringeStates,
+          hashLookup
+        )
       }
       stRef <- Ref.of[F, DagRepresentation](initST)
     } yield new BlockDagKeyValueStorage[F](
@@ -296,29 +347,17 @@ object BlockDagKeyValueStorage {
     )
 
   private def messageFromBlockMetadata(
-      block: BlockMetadata,
-      msgMap: Map[BlockHash, Message[BlockHash, Validator]],
-      heightMap: Map[Long, Set[BlockHash]]
-  ) = {
-    val parents = block.justifications
-
-    val highestParent = parents.map(msgMap(_).height).maxOption.getOrElse(0L)
-    val truncateRange = 0L to Math.max(highestParent - 100, 0L)
-    val toTruncate    = truncateRange.flatMap(heightMap.get).flatten.toSet
-
-    // Seen messages are all seen from justifications combined
-    val seen = parents.map(msgMap).flatMap(_.seen) + block.blockHash -- toTruncate
-    Message(
-      id = block.blockHash,
-      height = block.blockNum,
-      sender = block.sender,
-      senderSeq = block.seqNum,
-      bondsMap = block.bondsMap,
-      parents = parents,
-      fringe = block.fringe,
-      seen = seen
-    )
-  }
+      block: BlockMetadata
+  ): Message[BlockHash, Validator] = Message(
+    id = block.blockHash,
+    height = block.blockNum,
+    sender = block.sender,
+    senderSeq = block.seqNum,
+    bondsMap = block.bondsMap,
+    parents = block.justifications,
+    fringe = block.fringe,
+    seen = block.view
+  )
 
   def removeExpiredFromPool[F[_]: Monad](
       deployStore: KeyValueTypedStore[F, DeployId, Signed[DeployData]],

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
@@ -24,6 +24,8 @@ import fs2.concurrent.Channel
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
 import cats.effect.{Deferred, Ref, Temporal}
+import coop.rchain.models.Validator.Validator
+import coop.rchain.sdk.dag.View
 
 object NodeSyncing {
 
@@ -198,8 +200,11 @@ class NodeSyncing[F[_]
         _ <- Log[F].info(
               s"Adding ${PrettyPrinter.buildString(block, short = true)}."
             )
-        bmd = BlockMetadata.fromBlock(block)
-        _   <- BlockDagStorage[F].insert(bmd, block)
+        pMetas <- block.justifications.traverse(BlockDagStorage[F].lookupUnsafe)
+        // TODO remove this seen compute and put it directly into block, so LFS can be started
+        seen = View.compute[Validator, BlockMetadata](pMetas.toSet, _.sender, _.seqNum, _.view)
+        bmd  = BlockMetadata.fromBlock(block).copy(view = seen)
+        _    <- BlockDagStorage[F].insert(bmd, block)
       } yield ()
 
     for {

--- a/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
@@ -16,7 +16,9 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsDiff
 import coop.rchain.rspace.merger.{ChannelChange, StateChange, StateChangeMerger}
 import coop.rchain.rspace.syntax._
+import coop.rchain.sdk.dag.View.IncludeTop
 import coop.rchain.sdk.dag.merging.ConflictResolutionLogic
+import coop.rchain.sdk.syntax.all.mapSyntax
 import coop.rchain.shared.{Log, Stopwatch}
 import scodec.bits.ByteVector
 
@@ -29,10 +31,16 @@ final case class MergeScope(finalScope: Set[BlockHash], conflictScope: Set[Block
 
 object MergeScope {
 
-  def minGenJs(jss: Set[BlockHash], dag: DagRepresentation): Set[BlockHash] =
-    jss.filterNot(
-      j => jss.exists(j2 => (dag.dagMessageState.msgMap(j2).seen - j2).contains(j))
-    )
+  def minGenJs(jss: Set[BlockHash], dag: DagRepresentation): Set[BlockHash] = {
+    val metas = jss.map(dag.dagMessageState.msgMap.getUnsafe).map(x => x.sender -> x).toMap
+    metas
+      .filterNot {
+        case (v, m) =>
+          metas.exists { case (_, m1) => m1.seen.seen.get(v).exists(_.contains(m.senderSeq.toInt)) }
+      }
+      .map(_._2.id)
+      .toSet
+  }
 
   def findSingleTip(fringe: Set[BlockHash], dag: DagRepresentation): Option[BlockHash] =
     minGenJs(fringe, dag).toList match {
@@ -53,34 +61,34 @@ object MergeScope {
       mergeFringe: Set[BlockHash],
       finalFringe: Set[BlockHash],
       childMap: Map[BlockHash, Set[BlockHash]],
-      dagData: Map[BlockHash, Message[BlockHash, Validator]]
+      dagData: Map[BlockHash, Message[BlockHash, Validator]],
+      lookup: ((Validator, Long)) => Set[BlockHash]
   ): (MergeScope, Option[BlockHash]) = {
     val pruneFringe = dagData.pruneFringe(finalFringe, childMap).map(_.id)
-    fromFringes(mergeFringe, finalFringe, pruneFringe, dagData)
+    def hl(v: Validator, sN: Long): BlockHash = {
+      val l = lookup((v, sN))
+      assert(l.size == 1, "Equivocations are not supported")
+      l.head
+    }
+    fromFringes(mergeFringe, finalFringe, pruneFringe, dagData, hl)
   }
 
   def fromFringes(
       mergeFringe: Set[BlockHash],
       finalFringe: Set[BlockHash],
       pruneFringe: Set[BlockHash],
-      dagData: Map[BlockHash, Message[BlockHash, Validator]]
+      dagData: Map[BlockHash, Message[BlockHash, Validator]],
+      lookup: (Validator, Long) => BlockHash
   ): (MergeScope, Option[BlockHash]) = {
-    val mergeFringeMsgs = mergeFringe.map(dagData)
-    val finalFringeMsgs = finalFringe.map(dagData)
-    val pruneFringeMsgs = pruneFringe.map(dagData)
 
     // Conflict scope
-    val cScope = dagData.between(mergeFringeMsgs, finalFringeMsgs)
+    val cScopeIds = dagData.between(mergeFringe, finalFringe, lookup, IncludeTop)
 
     // Final scope
-    val fScope = dagData.between(finalFringeMsgs, pruneFringeMsgs)
-
-    // Scope ids
-    val cScopeIds = cScope.map(_.id)
-    val fScopeIds = fScope.map(_.id)
+    val fScopeIds = dagData.between(finalFringe, pruneFringe, lookup, IncludeTop)
 
     // Find base message if final scope is empty (genesis merging scope)
-    val baseMsg = Option(fScope).filter(_.isEmpty).flatMap { _ =>
+    val baseMsg = Option(fScopeIds).filter(_.isEmpty).flatMap { _ =>
       val genesisOpt = dagData.findWithEmptyParents
       assert(genesisOpt.nonEmpty, "Final scope is empty but no genesis found.")
       genesisOpt.map(_.id)

--- a/casper/src/main/scala/coop/rchain/casper/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/InterpreterUtil.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.rholang
 
+import cats.data.EitherT
 import cats.effect.{Async, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
@@ -31,6 +32,7 @@ import coop.rchain.rholang.interpreter.errors.InterpreterError
 import coop.rchain.shared.{Log, LogSource}
 import retry.{retryingOnFailures, RetryPolicies, Sleep}
 import cats.effect.Temporal
+import coop.rchain.sdk.dag.View
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -120,6 +122,8 @@ object InterpreterUtil {
           } yield result.map(_.isDefined)
         }
       }
+      pMetas <- block.justifications.traverse(BlockDagStorage[F].lookupUnsafe)
+      seen   = View.compute[Validator, BlockMetadata](pMetas.toSet, _.sender, _.seqNum, _.view)
     } yield {
       val bmd = BlockMetadata
         .fromBlock(block)
@@ -127,7 +131,8 @@ object InterpreterUtil {
           validated = true,
           validationFailed = result.isLeft || !result.toOption.get,
           fringe = preState.fringe,
-          fringeStateHash = preState.fringeState.bytes.toArray.toByteString
+          fringeStateHash = preState.fringeState.bytes.toArray.toByteString,
+          view = seen
         )
       (bmd, result)
     }

--- a/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
@@ -35,6 +35,7 @@ object RNodeKeyValueStoreManager {
       (Db("blocks"), blockStorageEnvConfig),
       // Block metadata storage
       (Db("block-metadata"), dagStorageEnvConfig),
+      (Db("lfs-set"), dagStorageEnvConfig),
       (Db("fringe-data"), dagStorageEnvConfig),
       (Db("finalized-store"), dagStorageEnvConfig),
       // Deploys from blocks

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -20,6 +20,7 @@ import coop.rchain.models.block.StateHash.StateHash
 import coop.rchain.models.blockImplicits.getRandomBlock
 import coop.rchain.models.syntax._
 import coop.rchain.models.{BlockMetadata, FringeData}
+import coop.rchain.sdk.dag.View
 import coop.rchain.shared.Log
 import org.mockito.cats.IdiomaticMockitoCats
 import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito, Mockito, MockitoSugar}
@@ -228,7 +229,8 @@ class BlockQueryResponseAPITest
             Set.empty,
             Set.empty
           )
-        )
+        ),
+        Map()
       )
     )
 
@@ -247,12 +249,12 @@ class BlockQueryResponseAPITest
 
         val seen = {
           val parents = b.justifications.map(s.dagMessageState.msgMap).toSet
-          val parentsAsSeen = DagSeen(
+          val parentsAsSeen = View(
             parents
               .map(x => x.sender -> Range.inclusive(x.senderSeq.toInt, x.senderSeq.toInt))
               .toMap
           )
-          Monoid[DagSeen[Validator]].combineAll(parents.map(_.seen) + parentsAsSeen)
+          Monoid[View[Validator]].combineAll(parents.map(_.seen) + parentsAsSeen)
         }
 
         val newMsgMap = s.dagMessageState.msgMap + (b.blockHash -> toMessage(b, seen))
@@ -286,7 +288,7 @@ class BlockQueryResponseAPITest
   // Default args only available for public method in Scala 2.12 (https://github.com/scala/bug/issues/12168)
   def toMessage(
       m: BlockMessage,
-      seen: DagSeen[Validator] = Monoid[DagSeen[Validator]].empty
+      seen: View[Validator] = Monoid[View[Validator]].empty
   ): Message[BlockHash, Validator] =
     Message[BlockHash, Validator](
       m.blockHash,

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.api
 
+import cats.Monoid
 import cats.effect.{IO, Ref, Sync}
 import cats.effect.testing.scalatest.AsyncIOSpec
 import cats.syntax.all._
@@ -244,9 +245,15 @@ class BlockQueryResponseAPITest
         val newHeightMap = s.heightMap + (b.blockNumber -> (s.heightMap
           .getOrElse(b.blockNumber, Set.empty) + b.blockHash))
 
-        val seen = b.justifications
-          .flatMap(h => s.dagMessageState.msgMap(h).seen)
-          .toSet ++ b.justifications + b.blockHash
+        val seen = {
+          val parents = b.justifications.map(s.dagMessageState.msgMap).toSet
+          val parentsAsSeen = DagSeen(
+            parents
+              .map(x => x.sender -> Range.inclusive(x.senderSeq.toInt, x.senderSeq.toInt))
+              .toMap
+          )
+          Monoid[DagSeen[Validator]].combineAll(parents.map(_.seen) + parentsAsSeen)
+        }
 
         val newMsgMap = s.dagMessageState.msgMap + (b.blockHash -> toMessage(b, seen))
 
@@ -279,7 +286,7 @@ class BlockQueryResponseAPITest
   // Default args only available for public method in Scala 2.12 (https://github.com/scala/bug/issues/12168)
   def toMessage(
       m: BlockMessage,
-      seen: Set[BlockHash] = Set.empty[BlockHash]
+      seen: DagSeen[Validator] = Monoid[DagSeen[Validator]].empty
   ): Message[BlockHash, Validator] =
     Message[BlockHash, Validator](
       m.blockHash,

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -14,6 +14,8 @@ import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.syntax._
 import coop.rchain.models.{BlockMetadata, FringeData}
+import coop.rchain.sdk.dag.View
+import coop.rchain.sdk.syntax.all.mapSyntax
 import coop.rchain.shared.Log
 import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito, Mockito}
 import org.scalatest.EitherValues
@@ -189,7 +191,8 @@ class BlocksResponseAPITest
             Set.empty,
             Set.empty
           )
-        )
+        ),
+        Map()
       )
     )
     val bds = mock[BlockDagStorage[F]]
@@ -205,9 +208,15 @@ class BlocksResponseAPITest
         val newHeightMap = s.heightMap + (b.blockNumber -> (s.heightMap
           .getOrElse(b.blockNumber, Set.empty) + b.blockHash))
 
-        val seen = b.justifications
-          .flatMap(h => s.dagMessageState.msgMap(h).seen)
-          .toSet ++ b.justifications + b.blockHash
+        val seen = {
+          val jsm = b.justifications.map(s.dagMessageState.msgMap.getUnsafe)
+          View.compute[Validator, Message[BlockHash, Validator]](
+            jsm.toSet,
+            _.sender,
+            _.senderSeq,
+            _.seen
+          )
+        }
 
         val newMsgMap = s.dagMessageState.msgMap + (b.blockHash -> toMessage(b, seen))
 
@@ -237,7 +246,7 @@ class BlocksResponseAPITest
   // Default args only available for public method in Scala 2.12 (https://github.com/scala/bug/issues/12168)
   def toMessage(
       m: BlockMessage,
-      seen: Set[BlockHash] = Set.empty[BlockHash]
+      seen: View[Validator] = View.semigroupDagSeen.empty
   ): Message[BlockHash, Validator] =
     Message[BlockHash, Validator](
       m.blockHash,

--- a/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
@@ -20,6 +20,7 @@ import coop.rchain.models.FringeData
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.blockImplicits.getRandomBlock
 import coop.rchain.models.syntax._
+import coop.rchain.sdk.dag.View
 import coop.rchain.shared.Log
 import coop.rchain.shared.scalatestcontrib._
 import org.mockito.cats.IdiomaticMockitoCats
@@ -27,8 +28,8 @@ import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import scala.collection.immutable.Seq
 
+import scala.collection.immutable.Seq
 import scala.collection.immutable.SortedMap
 
 class BondedStatusAPITest
@@ -143,7 +144,8 @@ class BondedStatusAPITest
           Set.empty,
           Set.empty
         )
-      )
+      ),
+      Map()
     )
 
     val bs = mock[BlockStore[F]]
@@ -166,7 +168,7 @@ class BondedStatusAPITest
       m.bonds,
       m.justifications.toSet,
       Set(m.blockHash),
-      Set(m.blockHash)
+      View.semigroupDagSeen.empty
     )
 
   private def bondedStatus[F[_]: Async: BlockDagStorage: BlockStore: Log: RuntimeManager: Span](

--- a/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
@@ -21,6 +21,7 @@ import coop.rchain.models._
 import coop.rchain.models.blockImplicits.getRandomBlock
 import coop.rchain.models.syntax._
 import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.sdk.dag.View
 import coop.rchain.shared.Log
 import org.mockito.cats.IdiomaticMockitoCats
 import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
@@ -85,7 +86,7 @@ class ExploratoryDeployAPITest
         bondsMap,
         blocks.get(blocks.indexOf(block) - 1L).map(b => Set(b.blockHash)).getOrElse(Set.empty),
         Set.empty,
-        blocks.take(blocks.indexOf(block) + 1).map(_.blockHash).toSet
+        View.semigroupDagSeen.empty
       )
 
     implicit val bds = mock[BlockDagStorage[IO]]
@@ -122,7 +123,8 @@ class ExploratoryDeployAPITest
           Set.empty,
           Set.empty
         )
-      )
+      ),
+      Map()
     )
 
     val term        = "new return in { for (@data <- @\"store\") {return!(data)}}"

--- a/casper/src/test/scala/coop/rchain/casper/api/LastFinalizedAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/LastFinalizedAPITest.scala
@@ -14,6 +14,7 @@ import coop.rchain.metrics.Span
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.syntax._
+import coop.rchain.sdk.dag.View
 import coop.rchain.shared.Log
 import org.mockito.IdiomaticMockito
 import org.mockito.cats.IdiomaticMockitoCats
@@ -118,7 +119,7 @@ class LastFinalizedAPITest
       Set.empty,
       // DAG contains only one message, which is finalized and sees itself
       Set(knownHashBS),
-      Set(knownHashBS)
+      View.semigroupDagSeen.empty
     )
 
     bds.getRepresentation returnsF DagRepresentation(
@@ -126,7 +127,8 @@ class LastFinalizedAPITest
       Map.empty,
       SortedMap.empty,
       new DagMessageState(Set(msg), Map(msg.id -> msg)),
-      Map.empty
+      Map.empty,
+      Map((createSender, 0.toLong) -> Set(knownHashBS))
     )
 
     (log, sp, rm, bs, bds)

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -27,6 +27,7 @@ import org.scalatest._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import cats.effect.testing.scalatest.AsyncIOSpec
+import coop.rchain.sdk.dag.View
 
 import scala.collection.immutable.SortedMap
 
@@ -158,7 +159,7 @@ class ListeningNameAPITest
       m.bonds,
       m.justifications.toSet,
       Set.empty,
-      Set(m.blockHash)
+      View.semigroupDagSeen.empty
     )
 
   private def createMocks[F[_]: Applicative]
@@ -190,7 +191,8 @@ class ListeningNameAPITest
       Map(m1.id    -> Set(m2.id, m3.id)),
       SortedMap(0L -> Set(m1.id), 1L -> Set(m2.id, m3.id)),
       new DagMessageState(Set(m2, m3), Map(m1.id -> m1, m2.id -> m2, m3.id -> m3)),
-      Map.empty
+      Map.empty,
+      Map()
     )
 
     (log, sp, rm, bs, bds)

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -129,7 +129,7 @@ class BlockReceiverEffectsSpec
   }
 
   private def blockDagStorageMock[F[_]: Applicative]: BlockDagStorage[F] = {
-    val emptyDag = DagRepresentation(Set(), Map(), SortedMap(), DagMessageState(), Map())
+    val emptyDag = DagRepresentation(Set(), Map(), SortedMap(), DagMessageState(), Map(), Map())
     mock[BlockDagStorage[F]].getRepresentation returnsF emptyDag
   }
 

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -205,9 +205,13 @@ message StoreItemsMessageProto {
 // --------- End Last finalized state  --------
 
 // --------- Internal types ---------
+message ViewProto {
+  bytes validator = 1;
+  int64 seqStart = 2;
+  int64 seqEnd = 3;
+}
 
 message BlockMetadataProto {
-  // BlockMessage data
   bytes blockHash               = 1;
   int64 blockNum                = 2;
   bytes sender                  = 3;
@@ -222,6 +226,8 @@ message BlockMetadataProto {
   bytes fringeStateHash         = 31;
   // Fringe where/when block is finalized
   bytes memberOfFringe          = 40;
+  // View of the block
+  repeated ViewProto view       = 41 [(scalapb.field).collection_type="List"];
 }
 
 message FringeDataProto {

--- a/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
@@ -1,7 +1,6 @@
 package coop.rchain.models
 
 import cats.syntax.all._
-import com.google.protobuf
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol._
 import coop.rchain.models.BlockHash.BlockHash
@@ -10,6 +9,7 @@ import coop.rchain.models.block.StateHash.StateHash
 import coop.rchain.models.syntax._
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.instances.RadixHistory
+import coop.rchain.sdk.dag.View
 
 final case class BlockMetadata(
     blockHash: BlockHash,
@@ -25,7 +25,8 @@ final case class BlockMetadata(
     fringe: Set[BlockHash],
     fringeStateHash: StateHash,
     // Fringe (fringe hash) where/when block is finalized
-    memberOfFringe: Option[Blake2b256Hash]
+    memberOfFringe: Option[Blake2b256Hash],
+    view: View[Validator]
 ) {
   // BlockMetadata is uniquely identified with BlockHash
   // - overridden hashCode is to be more performant when used in Set or Map
@@ -44,7 +45,8 @@ object BlockMetadata {
     b.validationFailed,
     b.fringe.toSet,
     b.fringeStateHash,
-    Option(b.memberOfFringe).filterNot(_.isEmpty).map(_.toBlake2b256Hash)
+    Option(b.memberOfFringe).filterNot(_.isEmpty).map(_.toBlake2b256Hash),
+    View(b.view.map(x => x.validator -> (x.seqStart.toInt to x.seqEnd.toInt)).toMap)
   )
 
   def toProto(b: BlockMetadata) = BlockMetadataProto(
@@ -58,7 +60,8 @@ object BlockMetadata {
     b.validationFailed,
     b.fringe.toList,
     b.fringeStateHash,
-    b.memberOfFringe.map(_.toByteString).getOrElse(ByteString.EMPTY)
+    b.memberOfFringe.map(_.toByteString).getOrElse(ByteString.EMPTY),
+    b.view.seen.toList.map { case (v, r) => ViewProto(v, r.start.toLong, r.end.toLong) }
   )
 
   def fromBytes(bytes: Array[Byte]): BlockMetadata =
@@ -66,6 +69,7 @@ object BlockMetadata {
 
   def toBytes(b: BlockMetadata) = BlockMetadata.toProto(b).toByteArray
 
+  // TODO consider default values to be put into BlockMessage to make LFS being reconstructed only from blocks feasible
   def fromBlock(b: BlockMessage): BlockMetadata =
     BlockMetadata(
       b.blockHash,
@@ -78,6 +82,7 @@ object BlockMetadata {
       validationFailed = false,
       fringe = Set(),
       fringeStateHash = RadixHistory.emptyRootHash.toByteString,
-      memberOfFringe = none
+      memberOfFringe = none,
+      view = View.semigroupDagSeen.empty
     )
 }

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -178,6 +178,8 @@ object HashM extends HashMDerivation {
   implicit val ContinuationAtNameResponseV2Hash = gen[v1.ContinuationAtNameResponse]
   implicit val FindDeployResponseV2Hash         = gen[v1.FindDeployResponse]
   implicit val LastFinalizedBlockResponseV2Hash = gen[v1.LastFinalizedBlockResponse]
+
+  implicit val viewProtoHash = gen[ViewProto]
 }
 
 trait HashMDerivation {

--- a/node/src/main/scala/coop/rchain/node/api/AdminWebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/AdminWebApi.scala
@@ -7,6 +7,7 @@ import coop.rchain.casper.api.BlockApi
 trait AdminWebApi[F[_]] {
   def propose: F[String]
   def proposeResult: F[String]
+  def vDag(depth: Int, startBlockNumber: Int, showJs: Boolean): F[String]
 }
 
 object AdminWebApi {
@@ -18,5 +19,11 @@ object AdminWebApi {
 
     def proposeResult: F[String] =
       blockApi.getProposeResult.flatMap(_.liftToBlockApiErr)
+
+    override def vDag(depth: Int, startBlockNumber: Int, showJs: Boolean): F[String] =
+      blockApi
+        .visualizeDag(depth, startBlockNumber, showJs)
+        .flatMap(_.liftToBlockApiErr)
+        .map(_.mkString)
   }
 }

--- a/node/src/main/scala/coop/rchain/node/api/v1/WebApiAdminEndpoints.scala
+++ b/node/src/main/scala/coop/rchain/node/api/v1/WebApiAdminEndpoints.scala
@@ -17,4 +17,13 @@ trait WebApiAdminEndpoints
     ok(jsonResponse[String]),
     docs = EndpointDocs().withDescription("Create and propose block".some)
   )
+
+  val vDag: Endpoint[Int, String] = endpoint(
+    get(path / "vdag" / dagDepth),
+    ok(textResponse),
+    docs = EndpointDocs().withDescription("Render dag in DOT format".some)
+  )
+
+  private lazy val dagDepth =
+    segment[Int](name = "depth", docs = "Depth of the Dag to render".some)
 }

--- a/node/src/main/scala/coop/rchain/node/web/AdminWebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/AdminWebApiRoutes.scala
@@ -26,6 +26,9 @@ object AdminWebApiRoutes {
     HttpRoutes.of[F] {
       case POST -> Root / "propose" =>
         adminWebApi.propose.handle
+
+      case POST -> Root / "vdag" / IntVar(depth) =>
+        adminWebApi.vDag(depth, 0, showJs = true).handle
     }
   }
 }

--- a/node/src/main/scala/coop/rchain/node/web/WebApiDocsV1.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiDocsV1.scala
@@ -30,7 +30,7 @@ object WebApiDocs
       getBlock
     )
 
-  val admin = Seq(propose)
+  val admin = Seq(propose, vDag)
 
   // Public API Open API schema
   val publicApi: OpenApi = openApi(Info(title = "RNode API", version = "1.0"))(public: _*)

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
@@ -89,6 +89,7 @@ final case class AdminWebApiRoutesV1[F[_]: Concurrent](
 
   val adminRoutes = routesFromEndpoints(
     // Propose
-    propose.implementedByEffect(const(adminWebApi.propose))
+    propose.implementedByEffect(const(adminWebApi.propose)),
+    vDag.implementedByEffect(adminWebApi.vDag(_: Int, 0, showJs = true))
   )
 }

--- a/sdk/src/main/scala/coop/rchain/sdk/dag/View.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/dag/View.scala
@@ -1,0 +1,64 @@
+package coop.rchain.sdk.dag
+
+import cats.Monoid
+
+// TODO Range here uses Int, but Long is used now to represent sequence numbers.
+//  Create custom RangeLong or implement another way to safely use Range here
+final case class View[S](seen: Map[S, Range]) {
+  assert(seen.forall(_._2.step == 1)) // ranges has to be continuous
+}
+
+object View {
+  trait IncludePolicy
+  object IncludeTop    extends IncludePolicy
+  object IncludeBottom extends IncludePolicy
+  object IncludeNone   extends IncludePolicy
+
+  implicit def semigroupDagSeen[S]: Monoid[View[S]] = new Monoid[View[S]] {
+    def combine(x: View[S], y: View[S]): View[S] = {
+      // new seen for each sender is from lowest amongst the two to highest amongst the two
+      val newSeen = x.seen.foldLeft(y.seen) {
+        case (acc, (sender, range)) =>
+          acc.get(sender) match {
+            case None => acc + (sender -> range)
+            case Some(range2) =>
+              val newRange = (range.start min range2.start) to (range.end max range2.end)
+              acc + (sender -> newRange)
+          }
+      }
+      View(newSeen)
+    }
+    override def empty: View[S] = View(Map.empty)
+  }
+
+  def diff[S](postfix: View[S], prefix: View[S], includePolicy: IncludePolicy): View[S] = {
+    val newSeen = prefix.seen.foldLeft(postfix.seen) {
+      case (acc, (sender, range)) =>
+        acc.get(sender) match {
+          case None => acc
+          case Some(range2) =>
+            val newRange = includePolicy match {
+              case IncludeTop    => (range.end + 1) to (range2.end)
+              case IncludeNone   => (range.end + 1) until (range2.end)
+              case IncludeBottom => range.end until (range2.end)
+            }
+            acc + (sender -> newRange)
+        }
+    }
+    View(newSeen)
+  }
+
+  def compute[S, M](
+      justifications: Set[M],
+      sender: M => S,
+      seqNum: M => Long,
+      seen: M => View[S]
+  ): View[S] = {
+    val parentsAsSeen = View(
+      justifications
+        .map(x => sender(x) -> Range.inclusive(seqNum(x).toInt, seqNum(x).toInt))
+        .toMap
+    )
+    Monoid[View[S]].combineAll(justifications.map(seen) + parentsAsSeen)
+  }
+}

--- a/sdk/src/test/scala/coop/rchain/sdk/ViewSpec.scala
+++ b/sdk/src/test/scala/coop/rchain/sdk/ViewSpec.scala
@@ -1,0 +1,48 @@
+package coop.rchain.sdk
+
+import cats.syntax.all._
+import coop.rchain.sdk.dag.View
+import coop.rchain.sdk.dag.View.{IncludeBottom, IncludeNone, IncludeTop}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ViewSpec extends AnyFlatSpec with Matchers {
+
+  "Combination of views" should "create a valid view" in {
+    val view1 = View(Map(1 -> Range.inclusive(1, 3), 2 -> Range.inclusive(1, 3)))
+    val view2 =
+      View(Map(1 -> Range.inclusive(1, 3), 2 -> Range.inclusive(2, 5), 3 -> Range.inclusive(1, 2)))
+
+    val ref = Map(
+      1 -> Range.inclusive(1, 3),
+      2 -> Range.inclusive(1, 5),
+      3 -> Range.inclusive(1, 2)
+    )
+
+    val r = List(view1, view2).combineAll
+    r.seen shouldBe ref
+  }
+
+  "Diff of views" should "create valid view" in {
+    val view1 = View(Map(1 -> Range.inclusive(1, 3), 2 -> Range.inclusive(1, 5)))
+    val view2 =
+      View(Map(1 -> Range.inclusive(1, 3), 2 -> Range.inclusive(1, 3), 3 -> Range.inclusive(1, 2)))
+
+    val refTop = Map(
+      1 -> Range(0, 0),
+      2 -> Range.inclusive(4, 5)
+    )
+    val refBottom = Map(
+      1 -> Range(0, 0),
+      2 -> Range.inclusive(3, 4)
+    )
+    val refNone = Map(
+      1 -> Range(0, 0),
+      2 -> Range.inclusive(4, 4)
+    )
+
+    View.diff(view1, view2, IncludeTop).seen shouldBe refTop
+    View.diff(view1, view2, IncludeBottom).seen shouldBe refBottom
+    View.diff(view1, view2, IncludeNone).seen shouldBe refNone
+  }
+}


### PR DESCRIPTION
## Overview
1. Persist and maintain the set of blocks required and sufficient to start node.
2. Add dag visualisation endpoint to http API. 
3. Remove set based view, add optimised view using validator and sequence number.

This allows
1. Quick restart regardless of the blockchain size
2. Preparation for LFS boot in multi parent settings (block merge).3. 

TODO: Handle equivocations in the view.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
