### PR TITLE
Optimise lfs state download

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
@@ -263,9 +263,21 @@ object LfsTupleSpaceRequester {
       } yield createStream(st, requestQueue)
     }
 
-    Log[F].info(s"Loading tuple space state for ${states.mkString("; ")}") *>
-      states
-        .traverse(loadState)
-        .map(Stream.emits(_).flatten)
+    states
+      .traverse(loadState)
+      .map(
+        Stream
+          .emits(_)
+          .zipWithIndex
+          .evalMap {
+            case (s, i) =>
+              Log[F]
+                .info(
+                  s"Loading tuple space state for root ${states(i.toInt)} ($i of ${states.size})"
+                )
+                .as(s)
+          }
+          .flatten
+      )
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
@@ -1,11 +1,10 @@
 package coop.rchain.casper.engine
 
-import cats.effect.{Async, Sync}
+import cats.effect.{Async, Ref, Sync}
 import cats.syntax.all._
 import coop.rchain.casper.protocol._
-import coop.rchain.models.syntax._
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.state.RSpaceImporter
+import coop.rchain.rspace.state.{RSpaceExporter, RSpaceImporter}
 import coop.rchain.shared.ByteVectorOps._
 import coop.rchain.shared.syntax._
 import coop.rchain.shared.{Log, Stopwatch}
@@ -14,7 +13,6 @@ import fs2.{Pure, Stream}
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
-import cats.effect.{Ref, Temporal}
 
 /**
   * Last Finalized State processor for receiving Rholang state.
@@ -110,6 +108,8 @@ object LfsTupleSpaceRequester {
       ) => F[Unit]
   ): F[Stream[F, ST[StatePartPath]]] = {
 
+    val receivedSIMs = Ref.unsafe(Set.empty[StatePartPath])
+
     def createStream(
         st: Ref[F, ST[StatePartPath]],
         requestQueue: Channel[F, Boolean]
@@ -156,9 +156,24 @@ object LfsTupleSpaceRequester {
         // Mark chunk as received
         isReceived <- Stream.eval(st.modify(_.received(startPath)))
 
+        isReceivedWithOtherRoot <- Stream.eval(receivedSIMs.modify { s =>
+                                    (s + startPath) -> s.contains(startPath)
+                                  })
+        _ <- Stream
+              .eval(
+                Log[F].debug(
+                  s"Short circuiting state fetch on ${startPath.map(RSpaceExporter.pathPretty).mkString(" ")}. " +
+                    s"Already received through another root request."
+                )
+              )
+              .whenA(isReceivedWithOtherRoot)
+
         // Add chunk paths for requesting and trigger request queue (without resend of already requested)
         _ <- Stream
-              .eval(st.update(_.add(Set(lastPath))) >> requestQueue.trySend(false))
+              .eval(
+                st.update(_.add(Set(lastPath))).unlessA(isReceivedWithOtherRoot) >>
+                  requestQueue.trySend(false)
+              )
               .whenA(isReceived)
 
         // Import chunk to RSpace

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
@@ -187,7 +187,7 @@ class NodeSyncing[F[_]
         TransportLayer[F].sendToBootstrap(
           StoreItemsMessageRequest(statePartPath, 0, pageSize).toProto
         ),
-      requestTimeout = 2.minutes,
+      requestTimeout = 10.seconds,
       RSpaceStateManager[F].importer,
       stateValidator
     )
@@ -207,7 +207,7 @@ class NodeSyncing[F[_]
                              incomingBlocksQueue.stream,
                              MultiParentCasper.deployLifespan,
                              hash => CommUtil[F].broadcastRequestForBlock(hash, 1.some),
-                             requestTimeout = 30.seconds,
+                             requestTimeout = 3.seconds,
                              BlockStore[F].contains(_),
                              BlockStore[F].getUnsafe,
                              BlockStore[F].put(_, _),


### PR DESCRIPTION
## Overview
Since LFS involves pulling merkle tree for numerous hashes, some data chunks can overlap. This is an optimisation to not request already pulled data.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
