### PR TITLE
Disable SSL

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -78,15 +78,15 @@ class GrpcTransportClient[F[_]: Async: Log: Metrics](
       d: Dispatcher[F]
   ): F[BufferedGrpcStreamChannel[F]] =
     for {
-      _                <- Log[F].info(s"Creating new channel to peer ${peer.toAddress}")
-      clientSslContext <- clientSslContextTask
+      _ <- Log[F].info(s"Creating new channel to peer ${peer.toAddress}")
+//      clientSslContext <- clientSslContextTask
       grpcChannel = NettyChannelBuilder
         .forAddress(peer.endpoint.host, peer.endpoint.tcpPort)
         .maxInboundMessageSize(maxMessageSize)
-        .negotiationType(NegotiationType.TLS)
-        .sslContext(clientSslContext)
-        .intercept(new SslSessionClientInterceptor[F](networkId, d))
-        .overrideAuthority(peer.id.toString)
+        .usePlaintext()
+//        .sslContext(clientSslContext)
+//        .intercept(new SslSessionClientInterceptor[F](networkId, d))
+//        .overrideAuthority(peer.id.toString)
         .build()
       buffer <- StreamObservable[F](peer, clientQueueSize, cache)
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -184,9 +184,14 @@ object GrpcTransportReceiver {
         NettyServerBuilder
           .forPort(port)
           .maxInboundMessageSize(maxMessageSize)
-          .sslContext(serverSslContext)
           .addService(TransportLayerFs2Grpc.bindService(d, service))
-          .intercept(new SslSessionServerInterceptor(networkId, d))
+          // SSL makes operator experience quite miserable, since after restart of the node with clean state and
+          // new generated self signed certificate it is effectively become ignored.
+          // What is the exact mechanism for this requires investigation, but anyway SSL without proper
+          // PKI infra does not make, and  even with proper one it is parallel for cryptography required for consensus.
+          // So using SSL is questionable here.
+//          .sslContext(serverSslContext)
+//          .intercept(new SslSessionServerInterceptor(networkId, d))
           .build
           .start
       )


### PR DESCRIPTION
## Overview
The biggest issue with SSL is that after node clean restart it cannot connect anymore to existing nodes.
This makes gRPC use plain text.

Look at in comments inside commit for more.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
