### PR TITLE
Lfs minimise

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
@@ -226,6 +226,7 @@ class NodeRunning[F[_]
     deployLifespan: Long
 ) {
   import NodeRunning._
+  import coop.rchain.models.BlockHash._
 
   /**
     * Check if block is stored in the BlockStore
@@ -283,7 +284,16 @@ class NodeRunning[F[_]
           if (x.isEmpty) dag.dagMessageState.latestMsgs.map(m => ProposeSlot(m.sender, 0L)) else x
         }
 
-        bootstrapDataMsg = BootstrapDataMessage(lms.toSeq, lowerBound)
+        finalStateHash = dag.fringeStates
+          .getUnsafe(
+            dag.dagMessageState.msgMap
+              .lowestFringe(dag.dagMessageState.latestMsgs)
+              .map(_.id)
+          )
+          .stateHash
+          .toByteString
+
+        bootstrapDataMsg = BootstrapDataMessage(lms.toSeq, lowerBound, finalStateHash)
 
         _ <- handleBootstrapDataRequest(peer, bootstrapDataMsg)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
@@ -147,7 +147,8 @@ class NodeSyncing[F[_]
         // Download approved state and all related blocks
         _ <- requestApprovedState(
               msg.tips.toSet,
-              msg.lowerBound.map(x => x.validator -> x.seqNum).toMap
+              msg.lowerBound.map(x => x.validator -> x.seqNum).toMap,
+              msg.finalStateHash.toBlake2b256Hash
             )
 
         // Approved block is saved after the whole state is received,
@@ -197,7 +198,8 @@ class NodeSyncing[F[_]
 
   def requestApprovedState(
       lms: Set[BlockHash],
-      edge: Map[Validator, Long]
+      edge: Map[Validator, Long],
+      finalStateHash: Blake2b256Hash
   ): F[Unit] =
     for {
       // Request all blocks for Last Finalized State
@@ -223,13 +225,13 @@ class NodeSyncing[F[_]
             .evalMap(
               BlockStore[F]
                 .getUnsafe(_)
-                .map(b => List(b.finStateHash, b.preStateHash, b.postStateHash))
+                .map(b => List(b.preStateHash, b.postStateHash))
             )
             .flatMap(fs2.Stream.emits)
             .map(_.toBlake2b256Hash)
             .compile
             .to(Set)
-            .flatMap(x => requestStates(x.toList)) *>
+            .flatMap(x => requestStates(finalStateHash +: x.toList)) *>
           Log[F].info(s"States for LFS received and imported.")
       }
       _ <- blockRequestAddDagStream.compile.drain

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
@@ -222,11 +222,14 @@ class NodeSyncing[F[_]
           Log[F].info(s"Blocks for LFS received and added to the state.") *>
           fs2.Stream
             .emits(st.heightMap.values.flatten.toList.distinct)
-            .evalMap(
-              BlockStore[F]
-                .getUnsafe(_)
-                .map(b => List(b.preStateHash, b.postStateHash))
-            )
+            .evalMap(BlockStore[F].getUnsafe)
+            // filter out blocks that had to be pulled just to have data to protect from replay attack
+            // (deployLifespan related)
+            .collect {
+              case b
+                  if (b.seqNum >= (edge.getUnsafe(b.sender) + MultiParentCasper.deployLifespan)) =>
+                List(b.preStateHash, b.postStateHash)
+            }
             .flatMap(fs2.Stream.emits)
             .map(_.toBlake2b256Hash)
             .compile

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -27,6 +27,7 @@ message BootstrapDataProto {
   option (scalapb.message).extends = "CasperMessageProto";
   repeated bytes tips = 1;
   repeated ProposeSlotProto lowerBound = 2;
+  bytes finalStateHash = 3;
 }
 
 message ProposeSlotProto {

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -578,7 +578,7 @@ object BootstrapDataMessage {
   implicit def showFF: Show[BootstrapDataMessage] = new Show[BootstrapDataMessage] {
     override def show(t: BootstrapDataMessage): String =
       s"tips: ${t.tips.map(_.toHexString.take(8))}, lowerBound: ${t.lowerBound
-        .map(x => x.validator.toHexString.take(8) -> x.seqNum)}, finalStateHash: ${t.finalStateHash}"
+        .map(x => x.validator.toHexString.take(8) -> x.seqNum)}, finalStateHash: ${t.finalStateHash.toBlake2b256Hash}"
   }
 }
 

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -555,7 +555,8 @@ object ProposeSlot {
 
 final case class BootstrapDataMessage(
     tips: Seq[BlockHash],
-    lowerBound: Set[ProposeSlot]
+    lowerBound: Set[ProposeSlot],
+    finalStateHash: ByteString
 ) extends CasperMessage {
   override def toProto: BootstrapDataProto = BootstrapDataMessage.toProto(this)
 }
@@ -564,18 +565,20 @@ object BootstrapDataMessage {
   def from(x: BootstrapDataProto): BootstrapDataMessage =
     BootstrapDataMessage(
       x.tips,
-      x.lowerBound.map(ProposeSlot.from).toSet
+      x.lowerBound.map(ProposeSlot.from).toSet,
+      x.finalStateHash
     )
   def toProto(x: BootstrapDataMessage): BootstrapDataProto =
     BootstrapDataProto(
       x.tips,
-      x.lowerBound.map(ProposeSlot.toProto).toSeq
+      x.lowerBound.map(ProposeSlot.toProto).toSeq,
+      x.finalStateHash
     )
 
   implicit def showFF: Show[BootstrapDataMessage] = new Show[BootstrapDataMessage] {
     override def show(t: BootstrapDataMessage): String =
       s"tips: ${t.tips.map(_.toHexString.take(8))}, lowerBound: ${t.lowerBound
-        .map(x => x.validator.toHexString.take(8) -> x.seqNum)}"
+        .map(x => x.validator.toHexString.take(8) -> x.seqNum)}, finalStateHash: ${t.finalStateHash}"
   }
 }
 

--- a/models/src/main/scala/coop/rchain/models/BlockHash.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockHash.scala
@@ -1,9 +1,13 @@
 package coop.rchain.models
 
+import cats.Show
 import com.google.protobuf.ByteString
+import coop.rchain.models.syntax.modelsSyntaxByteString
 
 object BlockHash {
   type BlockHash = ByteString
 
   val Length = 32
+
+  implicit val showBlockHash = Show.show[BlockHash](_.toHexString)
 }


### PR DESCRIPTION
## Overview
This disables pulling state roots that are not required to reconstruct merging indices (from blocks that are required to be pulled to enable replay attack protection). 
TODO pul merging indices directly. But enable pluggable serialisation before, too much of a headache otherwise.


<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
